### PR TITLE
Allow some skew on PDB maximum-prefix data

### DIFF
--- a/pierky/arouteserver/enrichers/pdb_max_prefix.py
+++ b/pierky/arouteserver/enrichers/pdb_max_prefix.py
@@ -41,9 +41,15 @@ class PeeringDBConfigEnricher_MaxPrefix_WorkerThread(BaseConfigEnricherThread):
                                cache_dir=self.cache_dir,
                                cache_expiry=self.cache_expiry)
             net.load_data()
+            if net.info_prefixes4:
+                net.info_prefixes4 += 100
+                net.info_prefixes4 *= 1.15
+            if net.info_prefixes6:
+                net.info_prefixes6 += 100
+                net.info_prefixes6 *= 1.15
 
-            return net.info_prefixes4 or self.general_limits["ipv4"], \
-                    net.info_prefixes6 or self.general_limits["ipv6"]
+            return int(net.info_prefixes4) or self.general_limits["ipv4"], \
+                    int(net.info_prefixes6) or self.general_limits["ipv6"]
 
         except PeeringDBNoInfoError:
             # No data found on PeeringDB.


### PR DESCRIPTION
PDB data cannot be used as literal values because there is no consensus in the community on what the values mean: it could be exact advertisement count or a hint on what to configure on your side. By adding 100 and adding 15% we accommodate both uses of the value.
 
This fixes #12 