### PR TITLE
Remove entirely insecure configuration mode

### DIFF
--- a/config.d/clients.yml
+++ b/config.d/clients.yml
@@ -146,9 +146,6 @@ clients:
             #- "NAME1"
             #- "NAME2"
 
-          #enforce_origin_in_as_set: True
-          #enforce_prefix_in_as_set: True
-
           # White lists.
           # The following 3 sections allow to configure white lists
           # for routes, prefixes and origin ASNs on a client-specific

--- a/config.d/general.yml
+++ b/config.d/general.yml
@@ -168,34 +168,6 @@ cfg:
         6762, 6830, 7018, 12956
 
     irrdb:
-      # With regards of the following two options, if no AS-SET
-      # is given in the clients configuration file for the
-      # specific client nor for its AS, then only the ASN
-      # of the announcing client is expanded and used to gather
-      # authorized origin ASNs and prefixes.
-      # If the 'peering_db' option below within this section is set
-      # to True, ARouteServer acquires the AS-SET of the client ASN
-      # from PeeringDB.
-      #
-      # More details on the Configuration page on ReadTheDocs:
-      # https://arouteserver.readthedocs.io/en/latest/CONFIG.html
-
-      # Accept only routes whose origin ASN is registered in
-      # the expanded AS-SET of the announcing client.
-      #
-      # Can be overwritten on a client-by-client basis.
-      #
-      # Default: True
-      enforce_origin_in_as_set: True
-
-      # Accept only prefixes which are present in the expanded
-      # AS-SET of the announcing client.
-      #
-      # Can be overwritten on a client-by-client basis.
-      #
-      # Default: True
-      enforce_prefix_in_as_set: True
-
       # By default, only prefixes that have a strict correspondence
       # in the route-set obtained by expading the AS-SET are
       # allowed.

--- a/docs/GENERAL.rst
+++ b/docs/GENERAL.rst
@@ -333,41 +333,6 @@ from PeeringDB.
 More details on the Configuration page on ReadTheDocs:
 https://arouteserver.readthedocs.io/en/latest/CONFIG.html
 
-- ``enforce_origin_in_as_set``:
-  Accept only routes whose origin ASN is registered in
-  the expanded AS-SET of the announcing client.
-
-
-  Can be overwritten on a client-by-client basis.
-
-
-  Default: **True**
-
-  Example:
-
-  .. code:: yaml
-
-     enforce_origin_in_as_set: True
-
-
-
-- ``enforce_prefix_in_as_set``:
-  Accept only prefixes which are present in the expanded
-  AS-SET of the announcing client.
-
-
-  Can be overwritten on a client-by-client basis.
-
-
-  Default: **True**
-
-  Example:
-
-  .. code:: yaml
-
-     enforce_prefix_in_as_set: True
-
-
 
 - ``allow_longer_prefixes``:
   By default, only prefixes that have a strict correspondence

--- a/examples/auto-config/bird-general.yml
+++ b/examples/auto-config/bird-general.yml
@@ -40,8 +40,6 @@ cfg:
       - 7018
       - 12956
     irrdb:
-      enforce_origin_in_as_set: true
-      enforce_prefix_in_as_set: true
       allow_longer_prefixes: true
       tag_as_set: true
       peering_db: true

--- a/examples/auto-config/openbgpd62-general.yml
+++ b/examples/auto-config/openbgpd62-general.yml
@@ -41,8 +41,6 @@ cfg:
       - 7018
       - 12956
     irrdb:
-      enforce_origin_in_as_set: true
-      enforce_prefix_in_as_set: true
       allow_longer_prefixes: true
       tag_as_set: true
       peering_db: true

--- a/examples/bird_hooks/general.yml
+++ b/examples/bird_hooks/general.yml
@@ -44,10 +44,6 @@ cfg:
         6762, 6830, 7018, 12956
 
     irrdb:
-      enforce_origin_in_as_set: True
-
-      enforce_prefix_in_as_set: True
-
       tag_as_set: True
 
     rpki:

--- a/examples/default/template-context
+++ b/examples/default/template-context
@@ -225,8 +225,6 @@ cfg:
       min: 12
     irrdb:
       allow_longer_prefixes: false
-      enforce_origin_in_as_set: true
-      enforce_prefix_in_as_set: true
       peering_db: false
       tag_as_set: true
       use_arin_bulk_whois_data:
@@ -638,8 +636,6 @@ clients:
           ? 454ed823addc298946e5f2ad415842d8a0a89403cf8ad05e584f94caf52ef799ca506a90f5386c1335f271047089bc0612014069cbb3d9a7851d595a0374c5c3
           : null
         as_sets: null
-        enforce_origin_in_as_set: true
-        enforce_prefix_in_as_set: true
         white_list_asn: null
         white_list_pref: null
         white_list_route: null
@@ -687,8 +683,6 @@ clients:
           ? a47487d3c1df7a14133a9cff3612f3af305e57bc54f1f212d6f8fb2da1da11949dea574d2c972b103143a62afb13ce6c93f8f89d3b0102b7113b54f8e1c8b341
           : null
         as_sets: null
-        enforce_origin_in_as_set: true
-        enforce_prefix_in_as_set: true
         white_list_asn: null
         white_list_pref: null
         white_list_route: null
@@ -736,8 +730,6 @@ clients:
           ? a47487d3c1df7a14133a9cff3612f3af305e57bc54f1f212d6f8fb2da1da11949dea574d2c972b103143a62afb13ce6c93f8f89d3b0102b7113b54f8e1c8b341
           : null
         as_sets: null
-        enforce_origin_in_as_set: true
-        enforce_prefix_in_as_set: true
         white_list_asn: null
         white_list_pref: null
         white_list_route: null

--- a/examples/default/template-context4
+++ b/examples/default/template-context4
@@ -225,8 +225,6 @@ cfg:
       min: 12
     irrdb:
       allow_longer_prefixes: false
-      enforce_origin_in_as_set: true
-      enforce_prefix_in_as_set: true
       peering_db: false
       tag_as_set: true
       use_arin_bulk_whois_data:
@@ -638,8 +636,6 @@ clients:
           ? 454ed823addc298946e5f2ad415842d8a0a89403cf8ad05e584f94caf52ef799ca506a90f5386c1335f271047089bc0612014069cbb3d9a7851d595a0374c5c3
           : null
         as_sets: null
-        enforce_origin_in_as_set: true
-        enforce_prefix_in_as_set: true
         white_list_asn: null
         white_list_pref: null
         white_list_route: null
@@ -687,8 +683,6 @@ clients:
           ? a47487d3c1df7a14133a9cff3612f3af305e57bc54f1f212d6f8fb2da1da11949dea574d2c972b103143a62afb13ce6c93f8f89d3b0102b7113b54f8e1c8b341
           : null
         as_sets: null
-        enforce_origin_in_as_set: true
-        enforce_prefix_in_as_set: true
         white_list_asn: null
         white_list_pref: null
         white_list_route: null

--- a/examples/default/template-context6
+++ b/examples/default/template-context6
@@ -225,8 +225,6 @@ cfg:
       min: 12
     irrdb:
       allow_longer_prefixes: false
-      enforce_origin_in_as_set: true
-      enforce_prefix_in_as_set: true
       peering_db: false
       tag_as_set: true
       use_arin_bulk_whois_data:
@@ -636,8 +634,6 @@ clients:
       irrdb:
         as_set_bundle_ids: !!set {}
         as_sets: null
-        enforce_origin_in_as_set: true
-        enforce_prefix_in_as_set: true
         white_list_asn: null
         white_list_pref: null
         white_list_route: null
@@ -683,8 +679,6 @@ clients:
       irrdb:
         as_set_bundle_ids: !!set {}
         as_sets: null
-        enforce_origin_in_as_set: true
-        enforce_prefix_in_as_set: true
         white_list_asn: null
         white_list_pref: null
         white_list_route: null

--- a/examples/rich/general.yml
+++ b/examples/rich/general.yml
@@ -44,10 +44,6 @@ cfg:
         6762, 6830, 7018, 12956
 
     irrdb:
-      enforce_origin_in_as_set: True
-
-      enforce_prefix_in_as_set: True
-
       tag_as_set: True
 
       allow_longer_prefixes: True

--- a/examples/rich/template-context
+++ b/examples/rich/template-context
@@ -247,8 +247,6 @@ cfg:
       min: 12
     irrdb:
       allow_longer_prefixes: true
-      enforce_origin_in_as_set: true
-      enforce_prefix_in_as_set: true
       peering_db: false
       tag_as_set: true
       use_arin_bulk_whois_data:
@@ -661,8 +659,6 @@ clients:
           ? 454ed823addc298946e5f2ad415842d8a0a89403cf8ad05e584f94caf52ef799ca506a90f5386c1335f271047089bc0612014069cbb3d9a7851d595a0374c5c3
           : null
         as_sets: null
-        enforce_origin_in_as_set: true
-        enforce_prefix_in_as_set: true
         white_list_asn: null
         white_list_pref: null
         white_list_route: null
@@ -712,8 +708,6 @@ clients:
           ? a47487d3c1df7a14133a9cff3612f3af305e57bc54f1f212d6f8fb2da1da11949dea574d2c972b103143a62afb13ce6c93f8f89d3b0102b7113b54f8e1c8b341
           : null
         as_sets: null
-        enforce_origin_in_as_set: true
-        enforce_prefix_in_as_set: true
         white_list_asn: null
         white_list_pref: null
         white_list_route: null

--- a/examples/rich/template-context4
+++ b/examples/rich/template-context4
@@ -247,8 +247,6 @@ cfg:
       min: 12
     irrdb:
       allow_longer_prefixes: true
-      enforce_origin_in_as_set: true
-      enforce_prefix_in_as_set: true
       peering_db: false
       tag_as_set: true
       use_arin_bulk_whois_data:
@@ -661,8 +659,6 @@ clients:
           ? 454ed823addc298946e5f2ad415842d8a0a89403cf8ad05e584f94caf52ef799ca506a90f5386c1335f271047089bc0612014069cbb3d9a7851d595a0374c5c3
           : null
         as_sets: null
-        enforce_origin_in_as_set: true
-        enforce_prefix_in_as_set: true
         white_list_asn: null
         white_list_pref: null
         white_list_route: null
@@ -712,8 +708,6 @@ clients:
           ? a47487d3c1df7a14133a9cff3612f3af305e57bc54f1f212d6f8fb2da1da11949dea574d2c972b103143a62afb13ce6c93f8f89d3b0102b7113b54f8e1c8b341
           : null
         as_sets: null
-        enforce_origin_in_as_set: true
-        enforce_prefix_in_as_set: true
         white_list_asn: null
         white_list_pref: null
         white_list_route: null

--- a/examples/rich/template-context6
+++ b/examples/rich/template-context6
@@ -247,8 +247,6 @@ cfg:
       min: 12
     irrdb:
       allow_longer_prefixes: true
-      enforce_origin_in_as_set: true
-      enforce_prefix_in_as_set: true
       peering_db: false
       tag_as_set: true
       use_arin_bulk_whois_data:
@@ -659,8 +657,6 @@ clients:
       irrdb:
         as_set_bundle_ids: !!set {}
         as_sets: null
-        enforce_origin_in_as_set: true
-        enforce_prefix_in_as_set: true
         white_list_asn: null
         white_list_pref: null
         white_list_route: null
@@ -708,8 +704,6 @@ clients:
       irrdb:
         as_set_bundle_ids: !!set {}
         as_sets: null
-        enforce_origin_in_as_set: true
-        enforce_prefix_in_as_set: true
         white_list_asn: null
         white_list_pref: null
         white_list_route: null

--- a/pierky/arouteserver/commands/configure.py
+++ b/pierky/arouteserver/commands/configure.py
@@ -279,8 +279,6 @@ class ConfigureCommand(ARouteServerCommand):
 
         filtering["irrdb"] = OrderedDict()
         irrdb = filtering["irrdb"]
-        irrdb["enforce_origin_in_as_set"] = True
-        irrdb["enforce_prefix_in_as_set"] = True
         irrdb["allow_longer_prefixes"] = True
         self.notes.append(
             "IRR-based filters are enabled; prefixes that are more specific "

--- a/pierky/arouteserver/config/clients.py
+++ b/pierky/arouteserver/config/clients.py
@@ -75,8 +75,6 @@ class ConfigParserClients(ConfigParserBase):
                     "irrdb": {
                         "as_sets": ValidatorListOf(ValidatorASSet,
                                                    mandatory=False),
-                        "enforce_origin_in_as_set": ValidatorBool(mandatory=False),
-                        "enforce_prefix_in_as_set": ValidatorBool(mandatory=False),
                         "white_list_pref": ValidatorListOf(
                             ValidatorPrefixListEntry, mandatory=False,
                         ),

--- a/pierky/arouteserver/config/general.py
+++ b/pierky/arouteserver/config/general.py
@@ -138,8 +138,6 @@ class ConfigParserGeneral(ConfigParserBase):
         f["irrdb"] = OrderedDict()
         i = f["irrdb"]
 
-        i["enforce_origin_in_as_set"] = ValidatorBool(default=True)
-        i["enforce_prefix_in_as_set"] = ValidatorBool(default=True)
         i["allow_longer_prefixes"] = ValidatorBool(default=False)
         i["tag_as_set"] = ValidatorBool(default=True)
         i["peering_db"] = ValidatorBool(default=False)

--- a/pierky/arouteserver/enrichers/irrdb.py
+++ b/pierky/arouteserver/enrichers/irrdb.py
@@ -246,12 +246,6 @@ class IRRDBConfigEnricher(BaseConfigEnricher):
             client_irrdb = client["cfg"]["filtering"]["irrdb"]
             client_irrdb["as_set_bundle_ids"] = set()
 
-            if not client_irrdb["enforce_origin_in_as_set"] and \
-                not client_irrdb["enforce_prefix_in_as_set"] and \
-                not self.builder.cfg_general["filtering"]["irrdb"]["tag_as_set"]:
-                    # Client does not require AS-SETs info to be gathered.
-                    continue
-
             if self.builder.ip_ver is not None:
                 ip = client["ip"]
                 if IPAddress(ip).version != self.builder.ip_ver:

--- a/pierky/arouteserver/enrichers/pdb_as_set.py
+++ b/pierky/arouteserver/enrichers/pdb_as_set.py
@@ -77,12 +77,6 @@ class PeeringDBConfigEnricher_ASSet(BaseConfigEnricher):
         for client in self.builder.cfg_clients.cfg["clients"]:
             client_irrdb = client["cfg"]["filtering"]["irrdb"]
 
-            if not client_irrdb["enforce_origin_in_as_set"] and \
-                not client_irrdb["enforce_prefix_in_as_set"] and \
-                not self.builder.cfg_general["filtering"]["irrdb"]["tag_as_set"]:
-                # Client does not require AS-SETs info to be gathered.
-                continue
-
             if client_irrdb["as_sets"]:
                 # Client has its own specific set of AS-SETs.
                 continue

--- a/pierky/arouteserver/tests/live_tests/skeleton/general.yml
+++ b/pierky/arouteserver/tests/live_tests/skeleton/general.yml
@@ -5,8 +5,6 @@ cfg:
         filtering:
                 irrdb:
                         tag_as_set: False
-                        enforce_origin_in_as_set: False
-                        enforce_prefix_in_as_set: False
                 rpki:
                         enabled: False
         communities:

--- a/templates/bird/clients.j2
+++ b/templates/bird/clients.j2
@@ -83,7 +83,6 @@ prefix set {{ client.id }}_blacklist;
 }
 {% endif %}
 
-{% if client.cfg.filtering.irrdb.enforce_origin_in_as_set or client.cfg.filtering.irrdb.enforce_prefix_in_as_set or cfg.filtering.irrdb.tag_as_set %}
 function verify_{{ client.id }}_irrdb()
 bool origin_ok;
 bool prefix_ok;
@@ -93,12 +92,8 @@ bool validated;
 	prefix_ok = false;
 	validated = false;
 
-{% 	if client.cfg.filtering.irrdb.enforce_origin_in_as_set or cfg.filtering.irrdb.tag_as_set %}
 	origin_ok = origin_as_is_in_{{ client.id }}_as_set();
-{%	endif %}
-{%	if client.cfg.filtering.irrdb.enforce_prefix_in_as_set or cfg.filtering.irrdb.tag_as_set %}
 	prefix_ok = prefix_is_in_{{ client.id }}_as_set();
-{%	endif %}
 
 {%	if cfg.filtering.irrdb.tag_as_set and cfg.communities.origin_not_present_in_as_set|community_is_set %}
 	if !origin_ok then {
@@ -164,18 +159,13 @@ bool validated;
 {%		endfor %}
 {%	endif %}
 
-{%	if client.cfg.filtering.irrdb.enforce_origin_in_as_set %}
 	if !validated && !origin_ok then {
 		{{ reject(client, 9, '"origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net', avoid_braces=True) }}
 	}
-{%	endif %}
-{%	if client.cfg.filtering.irrdb.enforce_prefix_in_as_set %}
 	if !validated && !prefix_ok then {
 		{{ reject(client, 12, '"prefix not in client\'s r_set - REJECTING ", net', avoid_braces=True) }}
 	}
-{%	endif %}
 }
-{% endif %}
 
 filter receive_from_{{ client.id }} {
 	if !(source = RTS_BGP ) then
@@ -244,10 +234,8 @@ filter receive_from_{{ client.id }} {
 	if prefix_is_bogon() then
 		{{ reject(client, 2, '"prefix is bogon - REJECTING ", net') }}
 
-	{% if client.cfg.filtering.irrdb.enforce_origin_in_as_set or client.cfg.filtering.irrdb.enforce_prefix_in_as_set or cfg.filtering.irrdb.tag_as_set %}
-	# IRRdb checks
+	# Filter checks
 	verify_{{ client.id }}_irrdb();
-	{% endif %}
 
 	# Blackhole request?
 	if is_blackhole_filtering_request() then {

--- a/templates/html/main.j2
+++ b/templates/html/main.j2
@@ -98,22 +98,14 @@ List of "transit-free" networks' ASNs:
 
 <ul>
 <li><p>
-Origin ASN validity is
-{% if not cfg.filtering.irrdb.enforce_origin_in_as_set %}
-<strong>not enforced.</strong>
-{% else %}
-<strong>enforced</strong>. Routes whose origin ASN is not authorized by the client's AS-SET are rejected.
-{% endif %}
+Origin ASN validity is <strong>enforced</strong>.
+Routes whose origin ASN is not authorized by the client's AS-SET are rejected.
 </p></li>
 
-<li><p>Announced prefixes validity is
-{% if not cfg.filtering.irrdb.enforce_prefix_in_as_set %}
-<strong>not enforced</strong>
-{% else %}
-<strong>enforced</strong>. Routes whose prefix is not part of the client's AS-SET are rejected.
-{%	if cfg.filtering.irrdb.allow_longer_prefixes %}
+<li><p>Announced prefixes validity is <strong>enforced</strong>.
+Routes whose prefix is not part of the client's AS-SET are rejected.
+{% if cfg.filtering.irrdb.allow_longer_prefixes %}
 Longer prefixes that are covered by one entry of the resulting route set are accepted.
-{%	endif %}
 {% endif %}
 </p></li>
 

--- a/templates/openbgpd/filters.j2
+++ b/templates/openbgpd/filters.j2
@@ -277,15 +277,11 @@ match from {{ client.ip }} prefix {{ write_prefix_list_entry(route) }} set ext-c
 {%	endfor %}
 {% endif %}
 
-{% if client.cfg.filtering.irrdb.enforce_origin_in_as_set or client.cfg.filtering.irrdb.enforce_prefix_in_as_set or cfg.filtering.irrdb.tag_as_set %}
 match from {{ client.ip }} set ext-community $INTCOMM_IRR_REJECT
-{% endif %}
 
-{% if client.cfg.filtering.irrdb.enforce_origin_in_as_set or cfg.filtering.irrdb.tag_as_set %}
 # AS_PATH: check origin via AS-SET
 {{ irrdb_filter(client, "asns", "$INTCOMM_ORIGIN_OK", "$INTCOMM_ORIGIN_KO",
 		cfg.communities.origin_present_in_as_set, cfg.communities.origin_not_present_in_as_set) -}}
-{% endif %}
 
 {% if client.cfg.filtering.black_list_pref %}
 # Prefix: client's blacklist
@@ -294,13 +290,10 @@ match from {{ client.ip }} set ext-community $INTCOMM_IRR_REJECT
 {{ deny_inbound_route(client_uses_tag_reject_policy, "from " ~ client.ip ~ " prefix $" ~ pref_list_name, 11) }}
 {% endif %}
 
-{% if client.cfg.filtering.irrdb.enforce_prefix_in_as_set or cfg.filtering.irrdb.tag_as_set %}
 # Prefix: check prefix via AS-SET
 {{ irrdb_filter(client, "prefixes", "$INTCOMM_PREFIX_OK", "$INTCOMM_PREFIX_KO",
 		cfg.communities.prefix_present_in_as_set, cfg.communities.prefix_not_present_in_as_set) -}}
-{% endif %}
 
-{% if client.cfg.filtering.irrdb.enforce_origin_in_as_set or client.cfg.filtering.irrdb.enforce_prefix_in_as_set or cfg.filtering.irrdb.tag_as_set %}
 
 {% if cfg.filtering.irrdb.use_rpki_roas_as_route_objects.enabled and rpki_roas %}
 # routes tagged with $INTCOMM_PREF_OK_ROA community have the prefix validated by a ROA; origin ASN previously validated ($INTCOMM_ORIGIN_OK)
@@ -341,7 +334,6 @@ match from {{ client.ip }} ext-community $INTCOMM_IRR_REJECT set community NO_AD
 match from {{ client.ip }} set community delete NO_ADVERTISE
 {% endif %}
 
-{% if client.cfg.filtering.irrdb.enforce_origin_in_as_set %}
 # enforcing: origin ASN
 # NO_ADVERTISE here means $INTCOMM_IRR_REJECT
 # (OpenBGPD does not allow matching multiple ext comms at once, so a std comm and an ext comm are used)
@@ -350,8 +342,7 @@ match from {{ client.ip }} ext-community $INTCOMM_IRR_REJECT set community NO_AD
 		      "from " ~ client.ip ~ " community NO_ADVERTISE ext-community $INTCOMM_ORIGIN_KO",
 		      9) }}
 match from {{ client.ip }} set community delete NO_ADVERTISE
-{% endif %}
-{% if client.cfg.filtering.irrdb.enforce_prefix_in_as_set %}
+
 # enforcing: prefix
 # NO_ADVERTISE here means $INTCOMM_IRR_REJECT
 # (OpenBGPD does not allow matching multiple ext comms at once, so a std comm and an ext comm are used)
@@ -360,8 +351,7 @@ match from {{ client.ip }} ext-community $INTCOMM_IRR_REJECT set community NO_AD
 		      "from " ~ client.ip ~ " community NO_ADVERTISE ext-community $INTCOMM_PREFIX_KO",
 		      12) }}
 match from {{ client.ip }} set community delete NO_ADVERTISE
-{% endif %}
-{% endif %}
+
 
 {% if ( client.ip|ipaddr_ver == 4 and cfg.blackhole_filtering.policy_ipv4 ) or
       ( client.ip|ipaddr_ver == 6 and cfg.blackhole_filtering.policy_ipv6 ) %}

--- a/tests/last
+++ b/tests/last
@@ -44,8 +44,6 @@ General config parser: deprecated syntax, RPKI Origin Validation ... ok
 General config parser: distributed config ... ok
 General config parser: duplicate communities ... ok
 General config parser: dyn_val macro usage in communities ... ok
-General config parser: enforce_origin_in_as_set ... ok
-General config parser: enforce_prefix_in_as_set ... ok
 General config parser: global_black_list_pref ... ok
 General config parser: graceful shutdown ... ok
 General config parser: gtsm ... ok

--- a/tests/live_tests/scenarios/communities/general.yml
+++ b/tests/live_tests/scenarios/communities/general.yml
@@ -6,8 +6,6 @@ cfg:
         filtering:
                 irrdb:
                         tag_as_set: False
-                        enforce_origin_in_as_set: False
-                        enforce_prefix_in_as_set: False
                 rpki:
                         enabled: False
         communities:

--- a/tests/live_tests/scenarios/global/clients.yml
+++ b/tests/live_tests/scenarios/global/clients.yml
@@ -77,8 +77,6 @@ clients:
                 add_path: True
                 filtering:
                         irrdb:
-                                enforce_origin_in_as_set: False
-                                enforce_prefix_in_as_set: False
                         black_list_pref:
                                 - prefix: "3.0.1.0"
                                   length: 24
@@ -94,5 +92,3 @@ clients:
           cfg:
                 filtering:
                         irrdb:
-                                enforce_origin_in_as_set: False
-                                enforce_prefix_in_as_set: False

--- a/tests/live_tests/scenarios/gshut/general.yml
+++ b/tests/live_tests/scenarios/gshut/general.yml
@@ -4,5 +4,3 @@ cfg:
         filtering:
                 irrdb:
                         tag_as_set: False
-                        enforce_origin_in_as_set: False
-                        enforce_prefix_in_as_set: False

--- a/tests/live_tests/scenarios/max_prefix/general_bird.yml
+++ b/tests/live_tests/scenarios/max_prefix/general_bird.yml
@@ -5,8 +5,6 @@ cfg:
         filtering:
                 irrdb:
                         tag_as_set: False
-                        enforce_origin_in_as_set: False
-                        enforce_prefix_in_as_set: False
                 max_prefix:
                         action: "block"
                         peering_db:

--- a/tests/live_tests/scenarios/max_prefix/general_openbgpd.yml
+++ b/tests/live_tests/scenarios/max_prefix/general_openbgpd.yml
@@ -5,8 +5,6 @@ cfg:
         filtering:
                 irrdb:
                         tag_as_set: False
-                        enforce_origin_in_as_set: False
-                        enforce_prefix_in_as_set: False
                 max_prefix:
                         action: "shutdown"
                         peering_db:

--- a/tests/live_tests/scenarios/path_hiding/general_off.yml
+++ b/tests/live_tests/scenarios/path_hiding/general_off.yml
@@ -5,8 +5,6 @@ cfg:
         add_path: True
         filtering:
                 irrdb:
-                        enforce_origin_in_as_set: False
-                        enforce_prefix_in_as_set: False
                         tag_as_set: False
         communities:
                 do_not_announce_to_peer:

--- a/tests/live_tests/scenarios/path_hiding/general_on.yml
+++ b/tests/live_tests/scenarios/path_hiding/general_on.yml
@@ -5,8 +5,6 @@ cfg:
         add_path: True
         filtering:
                 irrdb:
-                        enforce_origin_in_as_set: False
-                        enforce_prefix_in_as_set: False
                         tag_as_set: False
         communities:
                 do_not_announce_to_peer:

--- a/tests/live_tests/scenarios/rpki/general.yml
+++ b/tests/live_tests/scenarios/rpki/general.yml
@@ -3,8 +3,6 @@ cfg:
   router_id: "192.0.2.2"
   filtering:
     irrdb:
-      enforce_origin_in_as_set: False
-      enforce_prefix_in_as_set: False
       tag_as_set: False
     rpki_bgp_origin_validation:
       enabled: True

--- a/tests/live_tests/scenarios/tag_as_set/clients.yml
+++ b/tests/live_tests/scenarios/tag_as_set/clients.yml
@@ -31,7 +31,6 @@ clients:
           cfg:
                 filtering:
                         irrdb:
-                                enforce_origin_in_as_set: True
                                 as_sets:
                                 - "AS-AS4"
                                 white_list_pref:
@@ -68,7 +67,6 @@ clients:
           cfg:
                 filtering:
                         irrdb:
-                                enforce_prefix_in_as_set: True
                                 white_list_pref:
                                   - prefix: "5.2.0.0"
                                     length: 16
@@ -86,8 +84,6 @@ clients:
                         irrdb:
                                 as_sets:
                                 - "AS6"
-                                enforce_prefix_in_as_set: True
-                                enforce_origin_in_as_set: True
                                 white_list_route:
                                   - prefix: "3.2.0.0"
                                     length: 16

--- a/tests/live_tests/scenarios/tag_as_set/general.yml
+++ b/tests/live_tests/scenarios/tag_as_set/general.yml
@@ -5,8 +5,6 @@ cfg:
         filtering:
                 irrdb:
                         tag_as_set: True
-                        enforce_origin_in_as_set: False
-                        enforce_prefix_in_as_set: False
                         allow_longer_prefixes: True
                         peering_db: True
                         use_rpki_roas_as_route_objects:

--- a/tests/real/general.yml
+++ b/tests/real/general.yml
@@ -20,8 +20,6 @@ cfg:
         3257, 3320, 3356, 3549, 5511, 6453, 6461,
         6762, 6830, 7018, 12956
     irrdb:
-      enforce_origin_in_as_set: True
-      enforce_prefix_in_as_set: True
       allow_longer_prefixes: False
       tag_as_set: True
       peering_db: True

--- a/tests/static/data/test_cmd_show_config/distrib.txt
+++ b/tests/static/data/test_cmd_show_config/distrib.txt
@@ -18,8 +18,6 @@ configured          reject_invalid_as_in_as_path: True
 default               action: None
 configured            asns: 174, 209, 286, 701, 1239, 1299, 2828, 2914, 3257, 3320, 3356, 3549, 5511, 6453, 6461, 6762, 6830, 7018, 12956
                     irrdb:
-configured            enforce_origin_in_as_set: True
-configured            enforce_prefix_in_as_set: True
 configured            allow_longer_prefixes: False
 configured            tag_as_set: True
 configured            peering_db: False

--- a/tests/static/data/test_cmd_show_config/empty.txt
+++ b/tests/static/data/test_cmd_show_config/empty.txt
@@ -18,8 +18,6 @@ default             reject_invalid_as_in_as_path: True
 default               action: None
 default               asns: None
                     irrdb:
-default               enforce_origin_in_as_set: True
-default               enforce_prefix_in_as_set: True
 default               allow_longer_prefixes: False
 default               tag_as_set: True
 default               peering_db: False

--- a/tests/static/test_cfg_clients.py
+++ b/tests/static/test_cfg_clients.py
@@ -17,7 +17,7 @@ import unittest
 
 import yaml
 
-from .cfg_base import TestConfigParserBase 
+from .cfg_base import TestConfigParserBase
 from pierky.arouteserver.config.clients import ConfigParserClients
 from pierky.arouteserver.config.general import ConfigParserGeneral
 
@@ -160,8 +160,6 @@ class TestConfigParserClients(TestConfigParserBase):
             "      add_path: True",
             "      filtering:",
             "        irrdb:",
-            "          enforce_origin_in_as_set: False",
-            "          enforce_prefix_in_as_set: False",
             "          white_list_pref:",
             "            - prefix: 192.0.2.0",
             "              length: 24",
@@ -219,8 +217,6 @@ class TestConfigParserClients(TestConfigParserBase):
         self.assertEqual(client["cfg"]["passive"], True)
         self.assertEqual(client["cfg"]["add_path"], False)
         self.assertEqual(client["cfg"]["prepend_rs_as"], False)
-        self.assertEqual(client["cfg"]["filtering"]["irrdb"]["enforce_origin_in_as_set"], True)
-        self.assertEqual(client["cfg"]["filtering"]["irrdb"]["enforce_prefix_in_as_set"], True)
         self.assertEqual(client["cfg"]["filtering"]["irrdb"]["white_list_pref"], None)
         self.assertEqual(client["cfg"]["filtering"]["irrdb"]["white_list_asn"], None)
         self.assertEqual(client["cfg"]["filtering"]["rpki_bgp_origin_validation"]["enabled"], False)
@@ -282,7 +278,7 @@ class TestConfigParserClients(TestConfigParserBase):
             "  - asn: 111",
             "    ip: 192.0.2.11",
             "    cfg:",
-            "      blackhole_filtering:",             
+            "      blackhole_filtering:",
             "  - asn: 222",
             "    ip: 192.0.2.21",
             "    cfg:",
@@ -325,7 +321,7 @@ class TestConfigParserClients(TestConfigParserBase):
             "  rs_as: 999",
             "  router_id: 192.0.2.2",
             "  blackhole_filtering:",
-            "    announce_to_client: False"  
+            "    announce_to_client: False"
         ]))
         general.parse()
 

--- a/tests/static/test_cfg_general.py
+++ b/tests/static/test_cfg_general.py
@@ -22,7 +22,7 @@ import unittest
 
 import yaml
 
-from .cfg_base import TestConfigParserBase 
+from .cfg_base import TestConfigParserBase
 from pierky.arouteserver.config.general import ConfigParserGeneral
 from pierky.arouteserver.errors import ConfigError
 
@@ -53,7 +53,7 @@ class TestConfigParserGeneral(TestConfigParserBase):
             self.cfg["rs_as"] = asn
             self._contains_err("Error parsing 'rs_as' at 'cfg' level - Invalid ASN: {}".format(str(asn)))
 
-        for asn in (1, 65535, 4294967295): 
+        for asn in (1, 65535, 4294967295):
             self.cfg["rs_as"] = asn
             self._contains_err()
 
@@ -209,18 +209,6 @@ class TestConfigParserGeneral(TestConfigParserBase):
         self._test_bool_val(self.cfg["filtering"]["irrdb"], "tag_as_set")
         self._test_mandatory(self.cfg["filtering"]["irrdb"], "tag_as_set", has_default=True)
 
-    def test_enforce_origin_in_as_set(self):
-        """{}: enforce_origin_in_as_set"""
-        self.assertEqual(self.cfg["filtering"]["irrdb"]["enforce_origin_in_as_set"], True)
-        self._test_bool_val(self.cfg["filtering"]["irrdb"], "enforce_origin_in_as_set")
-        self._test_mandatory(self.cfg["filtering"]["irrdb"], "enforce_origin_in_as_set", has_default=True)
-
-    def test_enforce_prefix_in_as_set(self):
-        """{}: enforce_prefix_in_as_set"""
-        self.assertEqual(self.cfg["filtering"]["irrdb"]["enforce_prefix_in_as_set"], True)
-        self._test_bool_val(self.cfg["filtering"]["irrdb"], "enforce_prefix_in_as_set")
-        self._test_mandatory(self.cfg["filtering"]["irrdb"], "enforce_prefix_in_as_set", has_default=True)
-
     def test_allow_longer_prefixes(self):
         """{}: allow_longer_prefixes"""
         self.assertEqual(self.cfg["filtering"]["irrdb"]["allow_longer_prefixes"], False)
@@ -232,7 +220,7 @@ class TestConfigParserGeneral(TestConfigParserBase):
         self.assertEqual(self.cfg["filtering"]["irrdb"]["use_rpki_roas_as_route_objects"]["enabled"], False)
         self._test_bool_val(self.cfg["filtering"]["irrdb"]["use_rpki_roas_as_route_objects"], "enabled")
         self._test_mandatory(self.cfg["filtering"]["irrdb"]["use_rpki_roas_as_route_objects"], "enabled", has_default=True)
-        
+
     def test_use_rpki_roas_source(self):
         """{}: rpki_roas.source"""
         self.assertEqual(self.cfg["rpki_roas"]["source"], "ripe-rpki-validator-cache")
@@ -1075,8 +1063,6 @@ class TestConfigParserGeneral(TestConfigParserBase):
                 },
                 "irrdb": {
                     "tag_as_set": True,
-                    "enforce_origin_in_as_set": True,
-                    "enforce_prefix_in_as_set": True,
                     "allow_longer_prefixes": False,
                     "peering_db": False,
                     "use_rpki_roas_as_route_objects": {

--- a/tests/static/test_cmd_configure.py
+++ b/tests/static/test_cmd_configure.py
@@ -69,8 +69,6 @@ class TestConfigureCmd(ARouteServerTestCase):
                     ]
                 },
                 "irrdb": {
-                    "enforce_origin_in_as_set": True,
-                    "enforce_prefix_in_as_set": True,
                     "allow_longer_prefixes": True,
                     "tag_as_set": True,
                     "peering_db": True,

--- a/tests/static/test_enricher_irrdb.py
+++ b/tests/static/test_enricher_irrdb.py
@@ -31,8 +31,6 @@ class TestIRRDBEnricher_Base(unittest.TestCase):
             "router_id": "192.0.2.2",
             "filtering": {
                 "irrdb": {
-                    "enforce_origin_in_as_set": True,
-                    "enforce_prefix_in_as_set": True
                 }
             }
         }

--- a/tools/simulate/general.yml
+++ b/tools/simulate/general.yml
@@ -40,10 +40,6 @@ cfg:
         6762, 6830, 7018, 12956
 
     irrdb:
-      enforce_origin_in_as_set: True
-
-      enforce_prefix_in_as_set: True
-
       tag_as_set: True
 
       allow_longer_prefixes: True

--- a/utils/make_general.py
+++ b/utils/make_general.py
@@ -282,8 +282,6 @@ CFG = CfgStatement("cfg", t="General options", statement_pattern="^()(cfg):()", 
                 CfgStatement("asns", pre_comment=True)
             ]),
             CfgStatement("irrdb", t="IRRDB filters", post_comment=True, sub=[
-                CfgStatement("enforce_origin_in_as_set", pre_comment=True),
-                CfgStatement("enforce_prefix_in_as_set", pre_comment=True),
                 CfgStatement("allow_longer_prefixes", pre_comment=True),
                 CfgStatement("tag_as_set", pre_comment=True),
                 CfgStatement("peering_db", pre_comment=True),


### PR DESCRIPTION
In order to protect both IXP operator and IXP participants, we should
ensure that using arouteserver never leads to an insecure mode of
operation.

While arouteserver should offer a degree on flexibility in terms of
fine tuning what IRRs are used, whether ARIN WHOIS or RPKI is used
or not - there should not be a configuration path that leads to no
filters at all. Offering fully insecure modes is not user friendly.

This fixes #22