### PR TITLE
Prepare for OpenBSD 6.4

### DIFF
--- a/pierky/arouteserver/builder.py
+++ b/pierky/arouteserver/builder.py
@@ -731,8 +731,8 @@ class OpenBGPDConfigBuilder(ConfigBuilder):
                        "footer"]
     LOCAL_FILES_BASE_DIR = "/etc/bgpd"
 
-    AVAILABLE_VERSION = ["6.0", "6.1", "6.2", "6.3"]
-    DEFAULT_VERSION = "6.2"
+    AVAILABLE_VERSION = ["6.1", "6.2", "6.3", "6.4"]
+    DEFAULT_VERSION = "6.3"
 
     IGNORABLE_ISSUES = ["path_hiding", "transit_free_action",
                         "add_path", "max_prefix_action",

--- a/templates/openbgpd/clients.j2
+++ b/templates/openbgpd/clients.j2
@@ -54,7 +54,9 @@ group "clients" {
 {%	endif %}
 		enforce neighbor-as no
 
+{% if "6.4"|target_version_ge %}
 		announce all
+{% endif %}
 		announce as-4byte yes
 {%	if client.ip|ipaddr_ver == 4 %}
 		announce IPv6 none


### PR DESCRIPTION
Don't print `announce all` if we're building for 6.4

This fixes #31 