### PR TITLE
Rpki rtr config

### DIFF
--- a/config.d/general.yml
+++ b/config.d/general.yml
@@ -471,6 +471,8 @@ cfg:
     # - 'ripe-rpki-validator-cache': ROAs are fetched via
     #   HTTP from the RIPE RPKI Validator cache
     #   (http://localcert.ripe.net:8088/export.json by default).
+    # - 'rtr': Utilizing the RTR protocol, requires 'rtr_server'
+    #   and 'rtr_port' to be specified.
     #
     #   Please note that this method is far from guaranteeing
     #   that a cryptographically validated dataset is retrieved
@@ -484,6 +486,13 @@ cfg:
     # Default: ripe-rpki-validator-cache
     source: "ripe-rpki-validator-cache"
 
+    # Using the RTR protocol
+    # 'rtr_server': Specify remote server for using the RTR protocol
+    # Default: 127.0.0.1 
+    #
+    # 'rtr_port': Specify remote listening port of the RTR server
+    # Default: 323
+    #
     # RIPE RPKI Validator URL.
     # Meaningful only when 'source' is 'ripe-rpki-validator-cache'.
     # It can be an 'http://' or 'https://' URL or the path of a

--- a/pierky/arouteserver/config/general.py
+++ b/pierky/arouteserver/config/general.py
@@ -196,7 +196,7 @@ class ConfigParserGeneral(ConfigParserBase):
         c["rpki_roas"] = OrderedDict()
         r = c["rpki_roas"]
         r["source"] = ValidatorOption("source",
-            ("ripe-rpki-validator-cache", "rtrlib"),
+            ("ripe-rpki-validator-cache", "rtrlib","rtr"),
             mandatory=True,
             default="ripe-rpki-validator-cache"
         )
@@ -204,6 +204,8 @@ class ConfigParserGeneral(ConfigParserBase):
             mandatory=True,
             default="http://localcert.ripe.net:8088/export.json"
         )
+        r["rtr_server"] = ValidatorIPv4Addr(default="127.0.0.1")
+        r["rtr_port"] = ValidatorUInt(default=323)
         r["allowed_trust_anchors"] = ValidatorListOf(
             ValidatorText, mandatory=True, default=[
                 "APNIC from AFRINIC RPKI Root",


### PR DESCRIPTION
We are currently working on support for GoBGP into arouteserver and are looking into implementing template generation for using the native RTR support that comes with GoBGP.

For this I've added one new source ('rtr') and two new parameters into general.yml (rtr_server + rtr_port). The plan is to utilize these parameters when building the gobgp template.

Example configuration of GoBGP and how RPKI-RTR support is implemented is available here:
https://github.com/osrg/gobgp/blob/master/docs/sources/configuration.md