### PR TITLE
Perhaps s/bgp_path.last_nonaggregated/bgp_path.last/g

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -121,7 +121,7 @@ Most of this release is based on the work made by `Claudio Jeker <https://github
 v0.19.1
 -------
 
-- Fix (BIRD configuration only): change ``bgp_path.last`` with ``bgp_path.last_nonaggregated``.
+- Fix (BIRD configuration only): change ``bgp_path.last`` with ``bgp_path.last``.
 
   When a route is originated from the aggregation of two different routes using the AS_SET, ``bgp_path.last`` always returns 0, so the origin ASN validation against IRR always fails.
 

--- a/examples/bird2_rpki_rtr/bird_v2.conf
+++ b/examples/bird2_rpki_rtr/bird_v2.conf
@@ -384,7 +384,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -423,7 +423,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -570,7 +570,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -609,7 +609,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -760,7 +760,7 @@ protocol bgp AS10745_2 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -799,7 +799,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/examples/bird_hooks/bird4.conf
+++ b/examples/bird_hooks/bird4.conf
@@ -471,7 +471,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -519,7 +519,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -674,7 +674,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -722,7 +722,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/examples/bird_hooks/bird6.conf
+++ b/examples/bird_hooks/bird6.conf
@@ -509,7 +509,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -557,7 +557,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/examples/default/bird4.conf
+++ b/examples/default/bird4.conf
@@ -224,7 +224,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -262,7 +262,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -389,7 +389,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -427,7 +427,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/examples/default/bird6.conf
+++ b/examples/default/bird6.conf
@@ -262,7 +262,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -300,7 +300,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/examples/default/bird_v2.conf
+++ b/examples/default/bird_v2.conf
@@ -338,7 +338,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -377,7 +377,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -513,7 +513,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -552,7 +552,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -692,7 +692,7 @@ protocol bgp AS10745_2 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -731,7 +731,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/examples/rich/bird4.conf
+++ b/examples/rich/bird4.conf
@@ -1612,7 +1612,7 @@ function prefix_in_rpki_roas_as_route_objects() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_4;
 	}
 	return false;
@@ -1628,7 +1628,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -1690,7 +1690,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -1845,7 +1845,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -1907,7 +1907,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/examples/rich/bird6.conf
+++ b/examples/rich/bird6.conf
@@ -1643,7 +1643,7 @@ function prefix_in_rpki_roas_as_route_objects() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_6;
 	}
 	return false;
@@ -1659,7 +1659,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -1721,7 +1721,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/examples/rich/bird_v2.conf
+++ b/examples/rich/bird_v2.conf
@@ -1776,12 +1776,12 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_6;
 	}
 	}
@@ -1798,7 +1798,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -1861,7 +1861,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2023,7 +2023,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -2086,7 +2086,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2252,7 +2252,7 @@ protocol bgp AS10745_2 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -2315,7 +2315,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/templates/bird/clients.j2
+++ b/templates/bird/clients.j2
@@ -28,7 +28,7 @@ function origin_as_is_in_{{ client.id }}_as_set() {
 {% if client.cfg.filtering.irrdb.as_set_bundle_ids %}
 {%	for as_set_bundle_id in client.cfg.filtering.irrdb.as_set_bundle_ids|sort %}
 {%		if irrdb_info[as_set_bundle_id].asns %}
-	if bgp_path.last_nonaggregated ~ AS_SET_{{ irrdb_info[as_set_bundle_id].name }}_asns then
+	if bgp_path.last ~ AS_SET_{{ irrdb_info[as_set_bundle_id].name }}_asns then
 		return true;
 {%		else %}
 	# AS-SET {{ irrdb_info[as_set_bundle_id].name }} referenced but empty.
@@ -167,7 +167,7 @@ bool validated;
 {%		for route in client.cfg.filtering.irrdb.white_list_route|selectattr("prefix", "is_ipver", client.ip|ipaddr_ver)|sort(attribute="prefix") if route.prefix|ipaddr_ver == client.ip|ipaddr_ver %}
 	if !validated && net ~ [ {{ write_prefix_list_entry(route) }} ] then {
 {%			if route.asn %}
-		if bgp_path.last_nonaggregated = {{ route.asn }} then {
+		if bgp_path.last = {{ route.asn }} then {
 {%				if cfg.filtering.irrdb.tag_as_set and cfg.communities.route_validated_via_white_list|community_is_set %}
 {{					add_communities(cfg.communities.route_validated_via_white_list) }}
 {%				endif %}
@@ -185,7 +185,7 @@ bool validated;
 
 {%	if client.cfg.filtering.irrdb.enforce_origin_in_as_set %}
 	if !validated && !origin_ok then {
-		{{ reject(client, 9, '"origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net', avoid_braces=True) }}
+		{{ reject(client, 9, '"origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net', avoid_braces=True) }}
 	}
 {%	endif %}
 {%	if client.cfg.filtering.irrdb.enforce_prefix_in_as_set %}

--- a/templates/bird/common.j2
+++ b/templates/bird/common.j2
@@ -469,7 +469,7 @@ function prefix_in_arin_whois_db() {
 {%		if "2.0"|target_version_ge %}
 	if net.type = NET_IP{{ this_ip_ver }} then {
 {%		endif %}
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 {%		for origin_asn in arin_whois_records|sort %}
 {%			set prefixes = arin_whois_records[origin_asn].prefixes|selectattr("prefix", "is_ipver", this_ip_ver)|list %}
 {%			if prefixes|length > 0 %}
@@ -495,7 +495,7 @@ function prefix_in_registrobr_whois_db() {
 {%		if "2.0"|target_version_ge %}
 	if net.type = NET_IP{{ this_ip_ver }} then {
 {%		endif %}
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 {%		for origin_asn in registrobr_whois_records|sort %}
 {%			set prefixes = registrobr_whois_records[origin_asn].prefixes|selectattr("prefix", "is_ipver", this_ip_ver)|list %}
 {%			if prefixes|length > 0 %}

--- a/tests/live_tests/scenarios/bird2_rpki_rtr_example/configs/BIRD2RPKIRTRScenario_IPv4/bird2.conf
+++ b/tests/live_tests/scenarios/bird2_rpki_rtr_example/configs/BIRD2RPKIRTRScenario_IPv4/bird2.conf
@@ -407,7 +407,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -586,7 +586,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -769,7 +769,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/bird_hooks_example/configs/BIRDHooksExampleScenario_IPv4/bird16.conf
+++ b/tests/live_tests/scenarios/bird_hooks_example/configs/BIRDHooksExampleScenario_IPv4/bird16.conf
@@ -470,7 +470,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -518,7 +518,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -669,7 +669,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -717,7 +717,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/bird_hooks_example/configs/BIRDHooksExampleScenario_IPv6/bird16.conf
+++ b/tests/live_tests/scenarios/bird_hooks_example/configs/BIRDHooksExampleScenario_IPv6/bird16.conf
@@ -509,7 +509,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -557,7 +557,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/default/configs/DefaultConfigScenarioBIRD2_IPv4/bird2.conf
+++ b/tests/live_tests/scenarios/default/configs/DefaultConfigScenarioBIRD2_IPv4/bird2.conf
@@ -333,7 +333,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -372,7 +372,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -504,7 +504,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -541,7 +541,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -677,7 +677,7 @@ protocol bgp AS10745_2 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -716,7 +716,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/default/configs/DefaultConfigScenarioBIRD2_IPv6/bird2.conf
+++ b/tests/live_tests/scenarios/default/configs/DefaultConfigScenarioBIRD2_IPv6/bird2.conf
@@ -333,7 +333,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -370,7 +370,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -502,7 +502,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -541,7 +541,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -677,7 +677,7 @@ protocol bgp AS10745_2 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -714,7 +714,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/default/configs/DefaultConfigScenarioBIRD_IPv4/bird16.conf
+++ b/tests/live_tests/scenarios/default/configs/DefaultConfigScenarioBIRD_IPv4/bird16.conf
@@ -223,7 +223,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -261,7 +261,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -384,7 +384,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -422,7 +422,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/default/configs/DefaultConfigScenarioBIRD_IPv4/bird2.conf
+++ b/tests/live_tests/scenarios/default/configs/DefaultConfigScenarioBIRD_IPv4/bird2.conf
@@ -328,7 +328,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -367,7 +367,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -498,7 +498,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -535,7 +535,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -670,7 +670,7 @@ protocol bgp AS10745_2 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -709,7 +709,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/default/configs/DefaultConfigScenarioBIRD_IPv6/bird16.conf
+++ b/tests/live_tests/scenarios/default/configs/DefaultConfigScenarioBIRD_IPv6/bird16.conf
@@ -262,7 +262,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -300,7 +300,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/default/configs/DefaultConfigScenarioBIRD_IPv6/bird2.conf
+++ b/tests/live_tests/scenarios/default/configs/DefaultConfigScenarioBIRD_IPv6/bird2.conf
@@ -328,7 +328,7 @@ function add_noexport_noadvertise(int peer_as) {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -365,7 +365,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -496,7 +496,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -535,7 +535,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -670,7 +670,7 @@ protocol bgp AS10745_2 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -707,7 +707,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/global/configs/BasicScenario_BIRD2IPv4_Reject/bird2.conf
+++ b/tests/live_tests/scenarios/global/configs/BasicScenario_BIRD2IPv4_Reject/bird2.conf
@@ -1800,12 +1800,12 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_6;
 	}
 	}
@@ -1818,12 +1818,12 @@ function prefix_in_arin_whois_db() {
 # returns True, otherwise False.
 function prefix_in_registrobr_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_6;
 	}
 	}
@@ -1839,10 +1839,10 @@ function prefix_in_registrobr_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1897,7 +1897,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1906,7 +1906,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2060,9 +2060,9 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2116,7 +2116,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -2125,7 +2125,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2282,7 +2282,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2336,7 +2336,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2490,7 +2490,7 @@ protocol bgp AS1_3 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2542,7 +2542,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2700,7 +2700,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2753,7 +2753,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2908,7 +2908,7 @@ protocol bgp AS2_1 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2959,7 +2959,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/global/configs/BasicScenario_BIRD2IPv4_Tag/bird2.conf
+++ b/tests/live_tests/scenarios/global/configs/BasicScenario_BIRD2IPv4_Tag/bird2.conf
@@ -1832,12 +1832,12 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_6;
 	}
 	}
@@ -1850,12 +1850,12 @@ function prefix_in_arin_whois_db() {
 # returns True, otherwise False.
 function prefix_in_registrobr_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_6;
 	}
 	}
@@ -1871,10 +1871,10 @@ function prefix_in_registrobr_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1929,7 +1929,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1938,7 +1938,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2082,9 +2082,9 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2138,7 +2138,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -2147,7 +2147,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2293,7 +2293,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2347,7 +2347,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2491,7 +2491,7 @@ protocol bgp AS1_3 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2543,7 +2543,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2690,7 +2690,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2743,7 +2743,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2888,7 +2888,7 @@ protocol bgp AS2_1 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2939,7 +2939,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;

--- a/tests/live_tests/scenarios/global/configs/BasicScenario_BIRD2IPv6_Reject/bird2.conf
+++ b/tests/live_tests/scenarios/global/configs/BasicScenario_BIRD2IPv6_Reject/bird2.conf
@@ -1800,12 +1800,12 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_6;
 	}
 	}
@@ -1818,12 +1818,12 @@ function prefix_in_arin_whois_db() {
 # returns True, otherwise False.
 function prefix_in_registrobr_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_6;
 	}
 	}
@@ -1839,10 +1839,10 @@ function prefix_in_registrobr_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1895,7 +1895,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1904,7 +1904,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2057,9 +2057,9 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2115,7 +2115,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -2124,7 +2124,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2282,7 +2282,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2334,7 +2334,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2487,7 +2487,7 @@ protocol bgp AS1_3 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2541,7 +2541,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2700,7 +2700,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2751,7 +2751,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2905,7 +2905,7 @@ protocol bgp AS2_1 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2958,7 +2958,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/global/configs/BasicScenario_BIRD2IPv6_Tag/bird2.conf
+++ b/tests/live_tests/scenarios/global/configs/BasicScenario_BIRD2IPv6_Tag/bird2.conf
@@ -1832,12 +1832,12 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_6;
 	}
 	}
@@ -1850,12 +1850,12 @@ function prefix_in_arin_whois_db() {
 # returns True, otherwise False.
 function prefix_in_registrobr_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_6;
 	}
 	}
@@ -1871,10 +1871,10 @@ function prefix_in_registrobr_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1927,7 +1927,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1936,7 +1936,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2079,9 +2079,9 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2137,7 +2137,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -2146,7 +2146,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2293,7 +2293,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2345,7 +2345,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2488,7 +2488,7 @@ protocol bgp AS1_3 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2542,7 +2542,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2690,7 +2690,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2741,7 +2741,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2885,7 +2885,7 @@ protocol bgp AS2_1 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2938,7 +2938,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;

--- a/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv4_Reject/bird16.conf
+++ b/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv4_Reject/bird16.conf
@@ -1619,7 +1619,7 @@ function prefix_in_rpki_roas_as_route_objects() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_4;
 	}
 	return false;
@@ -1630,7 +1630,7 @@ function prefix_in_arin_whois_db() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_registrobr_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_4;
 	}
 	return false;
@@ -1645,10 +1645,10 @@ function prefix_in_registrobr_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1701,7 +1701,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1710,7 +1710,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -1855,7 +1855,7 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -1908,7 +1908,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2054,7 +2054,7 @@ protocol bgp AS1_3 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2106,7 +2106,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv4_Reject/bird2.conf
+++ b/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv4_Reject/bird2.conf
@@ -1795,12 +1795,12 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_6;
 	}
 	}
@@ -1813,12 +1813,12 @@ function prefix_in_arin_whois_db() {
 # returns True, otherwise False.
 function prefix_in_registrobr_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_6;
 	}
 	}
@@ -1834,10 +1834,10 @@ function prefix_in_registrobr_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1892,7 +1892,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1901,7 +1901,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2050,9 +2050,9 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2106,7 +2106,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -2115,7 +2115,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2267,7 +2267,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2321,7 +2321,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2470,7 +2470,7 @@ protocol bgp AS1_3 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2522,7 +2522,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2675,7 +2675,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2728,7 +2728,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2878,7 +2878,7 @@ protocol bgp AS2_1 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2929,7 +2929,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv4_Tag/bird16.conf
+++ b/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv4_Tag/bird16.conf
@@ -1651,7 +1651,7 @@ function prefix_in_rpki_roas_as_route_objects() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_4;
 	}
 	return false;
@@ -1662,7 +1662,7 @@ function prefix_in_arin_whois_db() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_registrobr_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_4;
 	}
 	return false;
@@ -1677,10 +1677,10 @@ function prefix_in_registrobr_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1733,7 +1733,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1742,7 +1742,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -1878,7 +1878,7 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -1931,7 +1931,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2068,7 +2068,7 @@ protocol bgp AS1_3 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2120,7 +2120,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;

--- a/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv4_Tag/bird2.conf
+++ b/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv4_Tag/bird2.conf
@@ -1827,12 +1827,12 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_6;
 	}
 	}
@@ -1845,12 +1845,12 @@ function prefix_in_arin_whois_db() {
 # returns True, otherwise False.
 function prefix_in_registrobr_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_6;
 	}
 	}
@@ -1866,10 +1866,10 @@ function prefix_in_registrobr_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1924,7 +1924,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1933,7 +1933,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2073,9 +2073,9 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2129,7 +2129,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -2138,7 +2138,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2280,7 +2280,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2334,7 +2334,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2474,7 +2474,7 @@ protocol bgp AS1_3 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2526,7 +2526,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2669,7 +2669,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2722,7 +2722,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2863,7 +2863,7 @@ protocol bgp AS2_1 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2914,7 +2914,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;

--- a/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv6_Reject/bird16.conf
+++ b/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv6_Reject/bird16.conf
@@ -1667,7 +1667,7 @@ function prefix_in_rpki_roas_as_route_objects() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_6;
 	}
 	return false;
@@ -1678,7 +1678,7 @@ function prefix_in_arin_whois_db() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_registrobr_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_6;
 	}
 	return false;
@@ -1693,9 +1693,9 @@ function prefix_in_registrobr_whois_db() {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -1749,7 +1749,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1758,7 +1758,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -1907,7 +1907,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -1960,7 +1960,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2110,7 +2110,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2162,7 +2162,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv6_Reject/bird2.conf
+++ b/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv6_Reject/bird2.conf
@@ -1795,12 +1795,12 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_6;
 	}
 	}
@@ -1813,12 +1813,12 @@ function prefix_in_arin_whois_db() {
 # returns True, otherwise False.
 function prefix_in_registrobr_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_6;
 	}
 	}
@@ -1834,10 +1834,10 @@ function prefix_in_registrobr_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1890,7 +1890,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1899,7 +1899,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2047,9 +2047,9 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2105,7 +2105,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -2114,7 +2114,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2267,7 +2267,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2319,7 +2319,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2467,7 +2467,7 @@ protocol bgp AS1_3 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2521,7 +2521,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2675,7 +2675,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2726,7 +2726,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2875,7 +2875,7 @@ protocol bgp AS2_1 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2928,7 +2928,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv6_Tag/bird16.conf
+++ b/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv6_Tag/bird16.conf
@@ -1699,7 +1699,7 @@ function prefix_in_rpki_roas_as_route_objects() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_6;
 	}
 	return false;
@@ -1710,7 +1710,7 @@ function prefix_in_arin_whois_db() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_registrobr_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_6;
 	}
 	return false;
@@ -1725,9 +1725,9 @@ function prefix_in_registrobr_whois_db() {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -1781,7 +1781,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1790,7 +1790,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -1929,7 +1929,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -1982,7 +1982,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2122,7 +2122,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2174,7 +2174,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;

--- a/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv6_Tag/bird2.conf
+++ b/tests/live_tests/scenarios/global/configs/BasicScenario_BIRDIPv6_Tag/bird2.conf
@@ -1827,12 +1827,12 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ ARIN_Whois_db_AS104_6;
 	}
 	}
@@ -1845,12 +1845,12 @@ function prefix_in_arin_whois_db() {
 # returns True, otherwise False.
 function prefix_in_registrobr_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		104: return net ~ RegistroBR_Whois_db_AS104_6;
 	}
 	}
@@ -1866,10 +1866,10 @@ function prefix_in_registrobr_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1922,7 +1922,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1931,7 +1931,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2070,9 +2070,9 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2128,7 +2128,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -2137,7 +2137,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2280,7 +2280,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2332,7 +2332,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2471,7 +2471,7 @@ protocol bgp AS1_3 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2525,7 +2525,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2669,7 +2669,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2720,7 +2720,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2860,7 +2860,7 @@ protocol bgp AS2_1 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2913,7 +2913,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;

--- a/tests/live_tests/scenarios/rich_example/configs/RichConfigExampleScenario_BIRD2IPv4/bird2.conf
+++ b/tests/live_tests/scenarios/rich_example/configs/RichConfigExampleScenario_BIRD2IPv4/bird2.conf
@@ -1771,12 +1771,12 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_6;
 	}
 	}
@@ -1793,7 +1793,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -1856,7 +1856,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2020,7 +2020,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -2081,7 +2081,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2249,7 +2249,7 @@ protocol bgp AS10745_2 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -2312,7 +2312,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/rich_example/configs/RichConfigExampleScenario_BIRD2IPv6/bird2.conf
+++ b/tests/live_tests/scenarios/rich_example/configs/RichConfigExampleScenario_BIRD2IPv6/bird2.conf
@@ -1771,12 +1771,12 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_6;
 	}
 	}
@@ -1793,7 +1793,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -1854,7 +1854,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2018,7 +2018,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -2081,7 +2081,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2249,7 +2249,7 @@ protocol bgp AS10745_2 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -2310,7 +2310,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/rich_example/configs/RichConfigExampleScenario_BIRDIPv4/bird16.conf
+++ b/tests/live_tests/scenarios/rich_example/configs/RichConfigExampleScenario_BIRDIPv4/bird16.conf
@@ -1611,7 +1611,7 @@ function prefix_in_rpki_roas_as_route_objects() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_4;
 	}
 	return false;
@@ -1627,7 +1627,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -1689,7 +1689,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -1844,7 +1844,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -1906,7 +1906,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/rich_example/configs/RichConfigExampleScenario_BIRDIPv4/bird2.conf
+++ b/tests/live_tests/scenarios/rich_example/configs/RichConfigExampleScenario_BIRDIPv4/bird2.conf
@@ -1766,12 +1766,12 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_6;
 	}
 	}
@@ -1788,7 +1788,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -1851,7 +1851,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2010,7 +2010,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -2071,7 +2071,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2234,7 +2234,7 @@ protocol bgp AS10745_2 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -2297,7 +2297,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/rich_example/configs/RichConfigExampleScenario_BIRDIPv6/bird16.conf
+++ b/tests/live_tests/scenarios/rich_example/configs/RichConfigExampleScenario_BIRDIPv6/bird16.conf
@@ -1643,7 +1643,7 @@ function prefix_in_rpki_roas_as_route_objects() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_6;
 	}
 	return false;
@@ -1659,7 +1659,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -1721,7 +1721,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/rich_example/configs/RichConfigExampleScenario_BIRDIPv6/bird2.conf
+++ b/tests/live_tests/scenarios/rich_example/configs/RichConfigExampleScenario_BIRDIPv6/bird2.conf
@@ -1766,12 +1766,12 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		10745: return net ~ ARIN_Whois_db_AS10745_6;
 	}
 	}
@@ -1788,7 +1788,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS10745_1
 function origin_as_is_in_AS10745_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -1849,7 +1849,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2008,7 +2008,7 @@ protocol bgp AS10745_1 {
 
 # AS-SET for AS10745_2
 function origin_as_is_in_AS10745_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS10745_asns then
+	if bgp_path.last ~ AS_SET_AS10745_asns then
 		return true;
 	return false;
 }
@@ -2071,7 +2071,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2234,7 +2234,7 @@ protocol bgp AS10745_2 {
 
 # AS-SET for AS3333_1
 function origin_as_is_in_AS3333_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS3333_asns then
+	if bgp_path.last ~ AS_SET_AS3333_asns then
 		return true;
 	return false;
 }
@@ -2295,7 +2295,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_EmptyAS_SETs_BIRD2IPv4/bird2.conf
+++ b/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_EmptyAS_SETs_BIRD2IPv4/bird2.conf
@@ -863,7 +863,7 @@ protocol bgp AS1_2 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_1_asns then
 		return true;
 	# AS-SET AS_AS2 referenced but empty.
 	return false;
@@ -1057,7 +1057,7 @@ protocol bgp AS2_1 {
 
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_2_asns then
 		return true;
 	# AS-SET AS2 referenced but empty.
 	# AS-SET AS_AS2 referenced but empty.
@@ -1256,7 +1256,7 @@ protocol bgp AS2_2 {
 
 # AS-SET for AS4_1
 function origin_as_is_in_AS4_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_1_asns then
 		return true;
 	# AS-SET AS4 referenced but empty.
 	# AS-SET AS_AS4 referenced but empty.
@@ -1326,7 +1326,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 4.4.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1334,7 +1334,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 4.5.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1349,7 +1349,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1480,7 +1480,7 @@ protocol bgp AS4_1 {
 function origin_as_is_in_AS4_2_as_set() {
 	# AS-SET AS4 referenced but empty.
 	# AS-SET AS_AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_2_asns then
 		return true;
 	return false;
 }
@@ -1548,7 +1548,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a04:4::/32 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1556,7 +1556,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 2a04:5::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1571,7 +1571,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1706,7 +1706,7 @@ protocol bgp AS4_2 {
 function origin_as_is_in_AS5_1_as_set() {
 	# AS-SET AS_AS5_FROM_PDB referenced but empty.
 	# AS-SET AS5 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_1_asns then
 		return true;
 	return false;
 }
@@ -1904,7 +1904,7 @@ protocol bgp AS5_1 {
 # AS-SET for AS5_2
 function origin_as_is_in_AS5_2_as_set() {
 	# AS-SET AS_AS5_FROM_PDB referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_2_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
 	return false;
@@ -2169,7 +2169,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 3.2.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2178,7 +2178,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2374,7 +2374,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a03:2::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2383,7 +2383,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_EmptyAS_SETs_BIRD2IPv6/bird2.conf
+++ b/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_EmptyAS_SETs_BIRD2IPv6/bird2.conf
@@ -863,7 +863,7 @@ protocol bgp AS1_2 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_1_asns then
 		return true;
 	# AS-SET AS_AS2 referenced but empty.
 	return false;
@@ -1057,7 +1057,7 @@ protocol bgp AS2_1 {
 
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_2_asns then
 		return true;
 	# AS-SET AS2 referenced but empty.
 	# AS-SET AS_AS2 referenced but empty.
@@ -1256,7 +1256,7 @@ protocol bgp AS2_2 {
 
 # AS-SET for AS4_1
 function origin_as_is_in_AS4_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_1_asns then
 		return true;
 	# AS-SET AS4 referenced but empty.
 	# AS-SET AS_AS4 referenced but empty.
@@ -1326,7 +1326,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 4.4.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1334,7 +1334,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 4.5.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1349,7 +1349,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1480,7 +1480,7 @@ protocol bgp AS4_1 {
 function origin_as_is_in_AS4_2_as_set() {
 	# AS-SET AS4 referenced but empty.
 	# AS-SET AS_AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_2_asns then
 		return true;
 	return false;
 }
@@ -1548,7 +1548,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a04:4::/32 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1556,7 +1556,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 2a04:5::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1571,7 +1571,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1706,7 +1706,7 @@ protocol bgp AS4_2 {
 function origin_as_is_in_AS5_1_as_set() {
 	# AS-SET AS_AS5_FROM_PDB referenced but empty.
 	# AS-SET AS5 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_1_asns then
 		return true;
 	return false;
 }
@@ -1904,7 +1904,7 @@ protocol bgp AS5_1 {
 # AS-SET for AS5_2
 function origin_as_is_in_AS5_2_as_set() {
 	# AS-SET AS_AS5_FROM_PDB referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_2_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
 	return false;
@@ -2169,7 +2169,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 3.2.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2178,7 +2178,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2374,7 +2374,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a03:2::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2383,7 +2383,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_EmptyAS_SETs_BIRDIPv4/bird16.conf
+++ b/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_EmptyAS_SETs_BIRDIPv4/bird16.conf
@@ -489,7 +489,7 @@ protocol bgp AS1_1 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_1_asns then
 		return true;
 	# AS-SET AS_AS2 referenced but empty.
 	return false;
@@ -673,7 +673,7 @@ protocol bgp AS2_1 {
 
 # AS-SET for AS4_1
 function origin_as_is_in_AS4_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_1_asns then
 		return true;
 	# AS-SET AS4 referenced but empty.
 	# AS-SET AS_AS4 referenced but empty.
@@ -742,7 +742,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 4.4.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -750,7 +750,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 4.5.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -765,7 +765,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -887,7 +887,7 @@ protocol bgp AS4_1 {
 function origin_as_is_in_AS5_1_as_set() {
 	# AS-SET AS_AS5_FROM_PDB referenced but empty.
 	# AS-SET AS5 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_1_asns then
 		return true;
 	return false;
 }
@@ -1137,7 +1137,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 3.2.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1146,7 +1146,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_EmptyAS_SETs_BIRDIPv4/bird2.conf
+++ b/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_EmptyAS_SETs_BIRDIPv4/bird2.conf
@@ -856,7 +856,7 @@ protocol bgp AS1_2 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_1_asns then
 		return true;
 	# AS-SET AS_AS2 referenced but empty.
 	return false;
@@ -1049,7 +1049,7 @@ protocol bgp AS2_1 {
 
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_2_asns then
 		return true;
 	# AS-SET AS2 referenced but empty.
 	# AS-SET AS_AS2 referenced but empty.
@@ -1247,7 +1247,7 @@ protocol bgp AS2_2 {
 
 # AS-SET for AS4_1
 function origin_as_is_in_AS4_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_1_asns then
 		return true;
 	# AS-SET AS4 referenced but empty.
 	# AS-SET AS_AS4 referenced but empty.
@@ -1317,7 +1317,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 4.4.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1325,7 +1325,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 4.5.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1340,7 +1340,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1470,7 +1470,7 @@ protocol bgp AS4_1 {
 function origin_as_is_in_AS4_2_as_set() {
 	# AS-SET AS4 referenced but empty.
 	# AS-SET AS_AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_2_asns then
 		return true;
 	return false;
 }
@@ -1538,7 +1538,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a04:4::/32 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1546,7 +1546,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 2a04:5::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1561,7 +1561,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1695,7 +1695,7 @@ protocol bgp AS4_2 {
 function origin_as_is_in_AS5_1_as_set() {
 	# AS-SET AS_AS5_FROM_PDB referenced but empty.
 	# AS-SET AS5 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_1_asns then
 		return true;
 	return false;
 }
@@ -1892,7 +1892,7 @@ protocol bgp AS5_1 {
 # AS-SET for AS5_2
 function origin_as_is_in_AS5_2_as_set() {
 	# AS-SET AS_AS5_FROM_PDB referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_2_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
 	return false;
@@ -2156,7 +2156,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 3.2.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2165,7 +2165,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2360,7 +2360,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a03:2::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2369,7 +2369,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_EmptyAS_SETs_BIRDIPv6/bird16.conf
+++ b/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_EmptyAS_SETs_BIRDIPv6/bird16.conf
@@ -540,7 +540,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_2_asns then
 		return true;
 	# AS-SET AS2 referenced but empty.
 	# AS-SET AS_AS2 referenced but empty.
@@ -731,7 +731,7 @@ protocol bgp AS2_2 {
 function origin_as_is_in_AS4_2_as_set() {
 	# AS-SET AS4 referenced but empty.
 	# AS-SET AS_AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_2_asns then
 		return true;
 	return false;
 }
@@ -798,7 +798,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a04:4::/32 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -806,7 +806,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 2a04:5::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -821,7 +821,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -946,7 +946,7 @@ protocol bgp AS4_2 {
 # AS-SET for AS5_2
 function origin_as_is_in_AS5_2_as_set() {
 	# AS-SET AS_AS5_FROM_PDB referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_2_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
 	return false;
@@ -1201,7 +1201,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a03:2::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1210,7 +1210,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_EmptyAS_SETs_BIRDIPv6/bird2.conf
+++ b/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_EmptyAS_SETs_BIRDIPv6/bird2.conf
@@ -856,7 +856,7 @@ protocol bgp AS1_2 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_1_asns then
 		return true;
 	# AS-SET AS_AS2 referenced but empty.
 	return false;
@@ -1049,7 +1049,7 @@ protocol bgp AS2_1 {
 
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_2_asns then
 		return true;
 	# AS-SET AS2 referenced but empty.
 	# AS-SET AS_AS2 referenced but empty.
@@ -1247,7 +1247,7 @@ protocol bgp AS2_2 {
 
 # AS-SET for AS4_1
 function origin_as_is_in_AS4_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_1_asns then
 		return true;
 	# AS-SET AS4 referenced but empty.
 	# AS-SET AS_AS4 referenced but empty.
@@ -1317,7 +1317,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 4.4.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1325,7 +1325,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 4.5.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1340,7 +1340,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1470,7 +1470,7 @@ protocol bgp AS4_1 {
 function origin_as_is_in_AS4_2_as_set() {
 	# AS-SET AS4 referenced but empty.
 	# AS-SET AS_AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_2_asns then
 		return true;
 	return false;
 }
@@ -1538,7 +1538,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a04:4::/32 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1546,7 +1546,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 2a04:5::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1561,7 +1561,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1695,7 +1695,7 @@ protocol bgp AS4_2 {
 function origin_as_is_in_AS5_1_as_set() {
 	# AS-SET AS_AS5_FROM_PDB referenced but empty.
 	# AS-SET AS5 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_1_asns then
 		return true;
 	return false;
 }
@@ -1892,7 +1892,7 @@ protocol bgp AS5_1 {
 # AS-SET for AS5_2
 function origin_as_is_in_AS5_2_as_set() {
 	# AS-SET AS_AS5_FROM_PDB referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_2_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
 	return false;
@@ -2156,7 +2156,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 3.2.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2165,7 +2165,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2360,7 +2360,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a03:2::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2369,7 +2369,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_WithAS_SETs_BIRD2IPv6/bird2.conf
+++ b/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_WithAS_SETs_BIRD2IPv6/bird2.conf
@@ -530,14 +530,14 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		2: return net ~ ARIN_Whois_db_AS2_4;
 		3: return net ~ ARIN_Whois_db_AS3_4;
 		6: return net ~ ARIN_Whois_db_AS6_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		2: return net ~ ARIN_Whois_db_AS2_6;
 		3: return net ~ ARIN_Whois_db_AS3_6;
 		6: return net ~ ARIN_Whois_db_AS6_6;
@@ -556,7 +556,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS1_asns then
+	if bgp_path.last ~ AS_SET_AS1_asns then
 		return true;
 	return false;
 }
@@ -752,7 +752,7 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS1_asns then
+	if bgp_path.last ~ AS_SET_AS1_asns then
 		return true;
 	return false;
 }
@@ -955,9 +955,9 @@ protocol bgp AS1_2 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_1_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_asns then
 		return true;
 	return false;
 }
@@ -1157,10 +1157,10 @@ protocol bgp AS2_1 {
 
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_2_asns then
 		return true;
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_asns then
 		return true;
 	return false;
 }
@@ -1366,10 +1366,10 @@ protocol bgp AS2_2 {
 
 # AS-SET for AS4_1
 function origin_as_is_in_AS4_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_1_asns then
 		return true;
 	# AS-SET AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS4_asns then
+	if bgp_path.last ~ AS_SET_AS_AS4_asns then
 		return true;
 	return false;
 }
@@ -1444,7 +1444,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 4.4.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1452,7 +1452,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 4.5.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1467,7 +1467,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1597,9 +1597,9 @@ protocol bgp AS4_1 {
 # AS-SET for AS4_2
 function origin_as_is_in_AS4_2_as_set() {
 	# AS-SET AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS4_asns then
+	if bgp_path.last ~ AS_SET_AS_AS4_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_2_asns then
 		return true;
 	return false;
 }
@@ -1676,7 +1676,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a04:4::/32 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1684,7 +1684,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 2a04:5::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1699,7 +1699,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1832,10 +1832,10 @@ protocol bgp AS4_2 {
 
 # AS-SET for AS5_1
 function origin_as_is_in_AS5_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS5_FROM_PDB_asns then
+	if bgp_path.last ~ AS_SET_AS_AS5_FROM_PDB_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_1_asns then
 		return true;
 	return false;
 }
@@ -2039,9 +2039,9 @@ protocol bgp AS5_1 {
 
 # AS-SET for AS5_2
 function origin_as_is_in_AS5_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS5_FROM_PDB_asns then
+	if bgp_path.last ~ AS_SET_AS_AS5_FROM_PDB_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_2_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
 	return false;
@@ -2252,7 +2252,7 @@ protocol bgp AS5_2 {
 
 # AS-SET for AS6_1
 function origin_as_is_in_AS6_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS6_asns then
+	if bgp_path.last ~ AS_SET_AS6_asns then
 		return true;
 	return false;
 }
@@ -2323,7 +2323,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 3.2.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2332,7 +2332,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2465,7 +2465,7 @@ protocol bgp AS6_1 {
 
 # AS-SET for AS6_2
 function origin_as_is_in_AS6_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS6_asns then
+	if bgp_path.last ~ AS_SET_AS6_asns then
 		return true;
 	return false;
 }
@@ -2538,7 +2538,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a03:2::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2547,7 +2547,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_WithAS_SETs_BIRDIPv4/bird16.conf
+++ b/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_WithAS_SETs_BIRDIPv4/bird16.conf
@@ -340,7 +340,7 @@ function prefix_in_rpki_roas_as_route_objects() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		2: return net ~ ARIN_Whois_db_AS2_4;
 		3: return net ~ ARIN_Whois_db_AS3_4;
 		6: return net ~ ARIN_Whois_db_AS6_4;
@@ -358,7 +358,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS1_asns then
+	if bgp_path.last ~ AS_SET_AS1_asns then
 		return true;
 	return false;
 }
@@ -547,9 +547,9 @@ protocol bgp AS1_1 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_1_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_asns then
 		return true;
 	return false;
 }
@@ -740,10 +740,10 @@ protocol bgp AS2_1 {
 
 # AS-SET for AS4_1
 function origin_as_is_in_AS4_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_1_asns then
 		return true;
 	# AS-SET AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS4_asns then
+	if bgp_path.last ~ AS_SET_AS_AS4_asns then
 		return true;
 	return false;
 }
@@ -818,7 +818,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 4.4.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -826,7 +826,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 4.5.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -841,7 +841,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -961,10 +961,10 @@ protocol bgp AS4_1 {
 
 # AS-SET for AS5_1
 function origin_as_is_in_AS5_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS5_FROM_PDB_asns then
+	if bgp_path.last ~ AS_SET_AS_AS5_FROM_PDB_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_1_asns then
 		return true;
 	return false;
 }
@@ -1159,7 +1159,7 @@ protocol bgp AS5_1 {
 
 # AS-SET for AS6_1
 function origin_as_is_in_AS6_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS6_asns then
+	if bgp_path.last ~ AS_SET_AS6_asns then
 		return true;
 	return false;
 }
@@ -1231,7 +1231,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 3.2.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1240,7 +1240,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_WithAS_SETs_BIRDIPv4/bird2.conf
+++ b/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_WithAS_SETs_BIRDIPv4/bird2.conf
@@ -525,14 +525,14 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		2: return net ~ ARIN_Whois_db_AS2_4;
 		3: return net ~ ARIN_Whois_db_AS3_4;
 		6: return net ~ ARIN_Whois_db_AS6_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		2: return net ~ ARIN_Whois_db_AS2_6;
 		3: return net ~ ARIN_Whois_db_AS3_6;
 		6: return net ~ ARIN_Whois_db_AS6_6;
@@ -551,7 +551,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS1_asns then
+	if bgp_path.last ~ AS_SET_AS1_asns then
 		return true;
 	return false;
 }
@@ -748,7 +748,7 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS1_asns then
+	if bgp_path.last ~ AS_SET_AS1_asns then
 		return true;
 	return false;
 }
@@ -948,9 +948,9 @@ protocol bgp AS1_2 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_1_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_asns then
 		return true;
 	return false;
 }
@@ -1151,10 +1151,10 @@ protocol bgp AS2_1 {
 
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_2_asns then
 		return true;
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_asns then
 		return true;
 	return false;
 }
@@ -1357,10 +1357,10 @@ protocol bgp AS2_2 {
 
 # AS-SET for AS4_1
 function origin_as_is_in_AS4_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_1_asns then
 		return true;
 	# AS-SET AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS4_asns then
+	if bgp_path.last ~ AS_SET_AS_AS4_asns then
 		return true;
 	return false;
 }
@@ -1437,7 +1437,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 4.4.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1445,7 +1445,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 4.5.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1460,7 +1460,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1589,9 +1589,9 @@ protocol bgp AS4_1 {
 # AS-SET for AS4_2
 function origin_as_is_in_AS4_2_as_set() {
 	# AS-SET AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS4_asns then
+	if bgp_path.last ~ AS_SET_AS_AS4_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_2_asns then
 		return true;
 	return false;
 }
@@ -1666,7 +1666,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a04:4::/32 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1674,7 +1674,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 2a04:5::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1689,7 +1689,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1821,10 +1821,10 @@ protocol bgp AS4_2 {
 
 # AS-SET for AS5_1
 function origin_as_is_in_AS5_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS5_FROM_PDB_asns then
+	if bgp_path.last ~ AS_SET_AS_AS5_FROM_PDB_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_1_asns then
 		return true;
 	return false;
 }
@@ -2029,9 +2029,9 @@ protocol bgp AS5_1 {
 
 # AS-SET for AS5_2
 function origin_as_is_in_AS5_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS5_FROM_PDB_asns then
+	if bgp_path.last ~ AS_SET_AS_AS5_FROM_PDB_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_2_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
 	return false;
@@ -2239,7 +2239,7 @@ protocol bgp AS5_2 {
 
 # AS-SET for AS6_1
 function origin_as_is_in_AS6_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS6_asns then
+	if bgp_path.last ~ AS_SET_AS6_asns then
 		return true;
 	return false;
 }
@@ -2312,7 +2312,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 3.2.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2321,7 +2321,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2453,7 +2453,7 @@ protocol bgp AS6_1 {
 
 # AS-SET for AS6_2
 function origin_as_is_in_AS6_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS6_asns then
+	if bgp_path.last ~ AS_SET_AS6_asns then
 		return true;
 	return false;
 }
@@ -2524,7 +2524,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a03:2::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2533,7 +2533,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_WithAS_SETs_BIRDIPv6/bird16.conf
+++ b/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_WithAS_SETs_BIRDIPv6/bird16.conf
@@ -388,7 +388,7 @@ function prefix_in_rpki_roas_as_route_objects() {
 # origin ASN to validate the announced prefix the function
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		2: return net ~ ARIN_Whois_db_AS2_6;
 		3: return net ~ ARIN_Whois_db_AS3_6;
 		6: return net ~ ARIN_Whois_db_AS6_6;
@@ -406,7 +406,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS1_asns then
+	if bgp_path.last ~ AS_SET_AS1_asns then
 		return true;
 	return false;
 }
@@ -598,10 +598,10 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_2_asns then
 		return true;
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_asns then
 		return true;
 	return false;
 }
@@ -797,9 +797,9 @@ protocol bgp AS2_2 {
 # AS-SET for AS4_2
 function origin_as_is_in_AS4_2_as_set() {
 	# AS-SET AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS4_asns then
+	if bgp_path.last ~ AS_SET_AS_AS4_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_2_asns then
 		return true;
 	return false;
 }
@@ -874,7 +874,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a04:4::/32 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -882,7 +882,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 2a04:5::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -897,7 +897,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1021,9 +1021,9 @@ protocol bgp AS4_2 {
 
 # AS-SET for AS5_2
 function origin_as_is_in_AS5_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS5_FROM_PDB_asns then
+	if bgp_path.last ~ AS_SET_AS_AS5_FROM_PDB_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_2_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
 	return false;
@@ -1223,7 +1223,7 @@ protocol bgp AS5_2 {
 
 # AS-SET for AS6_2
 function origin_as_is_in_AS6_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS6_asns then
+	if bgp_path.last ~ AS_SET_AS6_asns then
 		return true;
 	return false;
 }
@@ -1295,7 +1295,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a03:2::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1304,7 +1304,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_WithAS_SETs_BIRDIPv6/bird2.conf
+++ b/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_WithAS_SETs_BIRDIPv6/bird2.conf
@@ -525,14 +525,14 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		2: return net ~ ARIN_Whois_db_AS2_4;
 		3: return net ~ ARIN_Whois_db_AS3_4;
 		6: return net ~ ARIN_Whois_db_AS6_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		2: return net ~ ARIN_Whois_db_AS2_6;
 		3: return net ~ ARIN_Whois_db_AS3_6;
 		6: return net ~ ARIN_Whois_db_AS6_6;
@@ -551,7 +551,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS1_asns then
+	if bgp_path.last ~ AS_SET_AS1_asns then
 		return true;
 	return false;
 }
@@ -746,7 +746,7 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS1_asns then
+	if bgp_path.last ~ AS_SET_AS1_asns then
 		return true;
 	return false;
 }
@@ -948,9 +948,9 @@ protocol bgp AS1_2 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_1_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_asns then
 		return true;
 	return false;
 }
@@ -1149,10 +1149,10 @@ protocol bgp AS2_1 {
 
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_2_asns then
 		return true;
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_asns then
 		return true;
 	return false;
 }
@@ -1357,10 +1357,10 @@ protocol bgp AS2_2 {
 
 # AS-SET for AS4_1
 function origin_as_is_in_AS4_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_1_asns then
 		return true;
 	# AS-SET AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS4_asns then
+	if bgp_path.last ~ AS_SET_AS_AS4_asns then
 		return true;
 	return false;
 }
@@ -1435,7 +1435,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 4.4.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1443,7 +1443,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 4.5.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1458,7 +1458,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1587,9 +1587,9 @@ protocol bgp AS4_1 {
 # AS-SET for AS4_2
 function origin_as_is_in_AS4_2_as_set() {
 	# AS-SET AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS4_asns then
+	if bgp_path.last ~ AS_SET_AS_AS4_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_2_asns then
 		return true;
 	return false;
 }
@@ -1666,7 +1666,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a04:4::/32 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1674,7 +1674,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 2a04:5::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1689,7 +1689,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1821,10 +1821,10 @@ protocol bgp AS4_2 {
 
 # AS-SET for AS5_1
 function origin_as_is_in_AS5_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS5_FROM_PDB_asns then
+	if bgp_path.last ~ AS_SET_AS_AS5_FROM_PDB_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_1_asns then
 		return true;
 	return false;
 }
@@ -2027,9 +2027,9 @@ protocol bgp AS5_1 {
 
 # AS-SET for AS5_2
 function origin_as_is_in_AS5_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS5_FROM_PDB_asns then
+	if bgp_path.last ~ AS_SET_AS_AS5_FROM_PDB_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_2_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
 	return false;
@@ -2239,7 +2239,7 @@ protocol bgp AS5_2 {
 
 # AS-SET for AS6_1
 function origin_as_is_in_AS6_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS6_asns then
+	if bgp_path.last ~ AS_SET_AS6_asns then
 		return true;
 	return false;
 }
@@ -2310,7 +2310,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 3.2.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2319,7 +2319,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2451,7 +2451,7 @@ protocol bgp AS6_1 {
 
 # AS-SET for AS6_2
 function origin_as_is_in_AS6_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS6_asns then
+	if bgp_path.last ~ AS_SET_AS6_asns then
 		return true;
 	return false;
 }
@@ -2524,7 +2524,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a03:2::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2533,7 +2533,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_WithAS_SETs_BIRDsIPv4/bird2.conf
+++ b/tests/live_tests/scenarios/tag_as_set/configs/TagASSetScenario_WithAS_SETs_BIRDsIPv4/bird2.conf
@@ -530,14 +530,14 @@ function prefix_in_rpki_roas_as_route_objects() {
 # returns True, otherwise False.
 function prefix_in_arin_whois_db() {
 	if net.type = NET_IP4 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		2: return net ~ ARIN_Whois_db_AS2_4;
 		3: return net ~ ARIN_Whois_db_AS3_4;
 		6: return net ~ ARIN_Whois_db_AS6_4;
 	}
 	}
 	if net.type = NET_IP6 then {
-	case bgp_path.last_nonaggregated {
+	case bgp_path.last {
 		2: return net ~ ARIN_Whois_db_AS2_6;
 		3: return net ~ ARIN_Whois_db_AS3_6;
 		6: return net ~ ARIN_Whois_db_AS6_6;
@@ -556,7 +556,7 @@ function prefix_in_arin_whois_db() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS1_asns then
+	if bgp_path.last ~ AS_SET_AS1_asns then
 		return true;
 	return false;
 }
@@ -754,7 +754,7 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS1_asns then
+	if bgp_path.last ~ AS_SET_AS1_asns then
 		return true;
 	return false;
 }
@@ -955,9 +955,9 @@ protocol bgp AS1_2 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_1_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_asns then
 		return true;
 	return false;
 }
@@ -1159,10 +1159,10 @@ protocol bgp AS2_1 {
 
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS2_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS2_2_asns then
 		return true;
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_asns then
 		return true;
 	return false;
 }
@@ -1366,10 +1366,10 @@ protocol bgp AS2_2 {
 
 # AS-SET for AS4_1
 function origin_as_is_in_AS4_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_1_asns then
 		return true;
 	# AS-SET AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS4_asns then
+	if bgp_path.last ~ AS_SET_AS_AS4_asns then
 		return true;
 	return false;
 }
@@ -1446,7 +1446,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 4.4.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1454,7 +1454,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 4.5.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1469,7 +1469,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1599,9 +1599,9 @@ protocol bgp AS4_1 {
 # AS-SET for AS4_2
 function origin_as_is_in_AS4_2_as_set() {
 	# AS-SET AS4 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS4_asns then
+	if bgp_path.last ~ AS_SET_AS_AS4_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS4_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS4_2_asns then
 		return true;
 	return false;
 }
@@ -1676,7 +1676,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a04:4::/32 ] then {
-		if bgp_path.last_nonaggregated = 44 then {
+		if bgp_path.last = 44 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1684,7 +1684,7 @@ bool validated;
 		}
 	}
 	if !validated && net ~ [ 2a04:5::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 43 then {
+		if bgp_path.last = 43 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -1699,7 +1699,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 }
@@ -1832,10 +1832,10 @@ protocol bgp AS4_2 {
 
 # AS-SET for AS5_1
 function origin_as_is_in_AS5_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS5_FROM_PDB_asns then
+	if bgp_path.last ~ AS_SET_AS_AS5_FROM_PDB_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_1_asns then
 		return true;
 	return false;
 }
@@ -2041,9 +2041,9 @@ protocol bgp AS5_1 {
 
 # AS-SET for AS5_2
 function origin_as_is_in_AS5_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS5_FROM_PDB_asns then
+	if bgp_path.last ~ AS_SET_AS_AS5_FROM_PDB_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS5_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS5_2_asns then
 		return true;
 	# AS-SET AS5 referenced but empty.
 	return false;
@@ -2252,7 +2252,7 @@ protocol bgp AS5_2 {
 
 # AS-SET for AS6_1
 function origin_as_is_in_AS6_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS6_asns then
+	if bgp_path.last ~ AS_SET_AS6_asns then
 		return true;
 	return false;
 }
@@ -2325,7 +2325,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 3.2.0.0/16{16,32} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2334,7 +2334,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {
@@ -2467,7 +2467,7 @@ protocol bgp AS6_1 {
 
 # AS-SET for AS6_2
 function origin_as_is_in_AS6_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS6_asns then
+	if bgp_path.last ~ AS_SET_AS6_asns then
 		return true;
 	return false;
 }
@@ -2538,7 +2538,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a03:2::/32{32,128} ] then {
-		if bgp_path.last_nonaggregated = 3 then {
+		if bgp_path.last = 3 then {
 		bgp_community.add((999, 64517));
 		bgp_large_community.add((999, 0, 64517));
 
@@ -2547,7 +2547,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		reject "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net;
+		reject "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net;
 
 	}
 	if !validated && !prefix_ok then {

--- a/tests/live_tests/scenarios/tag_reject_policy/configs/TagRejectPolicyScenario_BIRD2IPv4/bird2.conf
+++ b/tests/live_tests/scenarios/tag_reject_policy/configs/TagRejectPolicyScenario_BIRD2IPv4/bird2.conf
@@ -1818,10 +1818,10 @@ function prefix_in_rpki_roas_as_route_objects() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1868,7 +1868,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1877,7 +1877,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2020,9 +2020,9 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2068,7 +2068,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -2077,7 +2077,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2223,7 +2223,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2269,7 +2269,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2412,7 +2412,7 @@ protocol bgp AS1_3 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2456,7 +2456,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2603,7 +2603,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2648,7 +2648,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2792,7 +2792,7 @@ protocol bgp AS2_1 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2835,7 +2835,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;

--- a/tests/live_tests/scenarios/tag_reject_policy/configs/TagRejectPolicyScenario_BIRD2IPv6/bird2.conf
+++ b/tests/live_tests/scenarios/tag_reject_policy/configs/TagRejectPolicyScenario_BIRD2IPv6/bird2.conf
@@ -1818,10 +1818,10 @@ function prefix_in_rpki_roas_as_route_objects() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1866,7 +1866,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1875,7 +1875,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2018,9 +2018,9 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2068,7 +2068,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -2077,7 +2077,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2223,7 +2223,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2267,7 +2267,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2410,7 +2410,7 @@ protocol bgp AS1_3 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2456,7 +2456,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2603,7 +2603,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2646,7 +2646,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2790,7 +2790,7 @@ protocol bgp AS2_1 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2835,7 +2835,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;

--- a/tests/live_tests/scenarios/tag_reject_policy/configs/TagRejectPolicyScenario_BIRDIPv4/bird16.conf
+++ b/tests/live_tests/scenarios/tag_reject_policy/configs/TagRejectPolicyScenario_BIRDIPv4/bird16.conf
@@ -1644,10 +1644,10 @@ function prefix_in_rpki_roas_as_route_objects() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1692,7 +1692,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1701,7 +1701,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -1836,7 +1836,7 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -1881,7 +1881,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2017,7 +2017,7 @@ protocol bgp AS1_3 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2061,7 +2061,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;

--- a/tests/live_tests/scenarios/tag_reject_policy/configs/TagRejectPolicyScenario_BIRDIPv4/bird2.conf
+++ b/tests/live_tests/scenarios/tag_reject_policy/configs/TagRejectPolicyScenario_BIRDIPv4/bird2.conf
@@ -1813,10 +1813,10 @@ function prefix_in_rpki_roas_as_route_objects() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1863,7 +1863,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1872,7 +1872,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2011,9 +2011,9 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2059,7 +2059,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -2068,7 +2068,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2210,7 +2210,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2256,7 +2256,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2395,7 +2395,7 @@ protocol bgp AS1_3 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2439,7 +2439,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2582,7 +2582,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2627,7 +2627,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2767,7 +2767,7 @@ protocol bgp AS2_1 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2810,7 +2810,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;

--- a/tests/live_tests/scenarios/tag_reject_policy/configs/TagRejectPolicyScenario_BIRDIPv6/bird16.conf
+++ b/tests/live_tests/scenarios/tag_reject_policy/configs/TagRejectPolicyScenario_BIRDIPv6/bird16.conf
@@ -1692,9 +1692,9 @@ function prefix_in_rpki_roas_as_route_objects() {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -1740,7 +1740,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1749,7 +1749,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -1887,7 +1887,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -1932,7 +1932,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2071,7 +2071,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2115,7 +2115,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;

--- a/tests/live_tests/scenarios/tag_reject_policy/configs/TagRejectPolicyScenario_BIRDIPv6/bird2.conf
+++ b/tests/live_tests/scenarios/tag_reject_policy/configs/TagRejectPolicyScenario_BIRDIPv6/bird2.conf
@@ -1813,10 +1813,10 @@ function prefix_in_rpki_roas_as_route_objects() {
 
 # AS-SET for AS1_1
 function origin_as_is_in_AS1_1_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_1_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_1_asns then
 		return true;
 	return false;
 }
@@ -1861,7 +1861,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 11.3.0.0/16 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -1870,7 +1870,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2009,9 +2009,9 @@ protocol bgp AS1_1 {
 
 # AS-SET for AS1_2
 function origin_as_is_in_AS1_2_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
-	if bgp_path.last_nonaggregated ~ AS_SET_WHITE_LIST_AS1_2_asns then
+	if bgp_path.last ~ AS_SET_WHITE_LIST_AS1_2_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2059,7 +2059,7 @@ bool validated;
 
 	# Client's white list
 	if !validated && net ~ [ 2a11:3::/32 ] then {
-		if bgp_path.last_nonaggregated = 1011 then {
+		if bgp_path.last = 1011 then {
 			validated = true;
 		}
 	}
@@ -2068,7 +2068,7 @@ bool validated;
 	}
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2210,7 +2210,7 @@ protocol bgp AS1_2 {
 
 # AS-SET for AS1_3
 function origin_as_is_in_AS1_3_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2254,7 +2254,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2393,7 +2393,7 @@ protocol bgp AS1_3 {
 
 # AS-SET for AS1_4
 function origin_as_is_in_AS1_4_as_set() {
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS1_AS_AS1_CUSTOMERS_asns then
 		return true;
 	# AS-SET AS1 referenced but empty.
 	return false;
@@ -2439,7 +2439,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 1); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 1); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2582,7 +2582,7 @@ protocol bgp AS1_4 {
 # AS-SET for AS2_1
 function origin_as_is_in_AS2_1_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2625,7 +2625,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;
@@ -2765,7 +2765,7 @@ protocol bgp AS2_1 {
 # AS-SET for AS2_2
 function origin_as_is_in_AS2_2_as_set() {
 	# AS-SET AS2 referenced but empty.
-	if bgp_path.last_nonaggregated ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
+	if bgp_path.last ~ AS_SET_AS_AS2_AS_AS2_CUSTOMERS_asns then
 		return true;
 	return false;
 }
@@ -2810,7 +2810,7 @@ bool validated;
 
 
 	if !validated && !origin_ok then {
-		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last_nonaggregated, "] not in allowed as-sets - REJECTING ", net; accept;
+		tag_and_reject(9, 2); print "origin ASN [", bgp_path.last, "] not in allowed as-sets - REJECTING ", net; accept;
 	}
 	if !validated && !prefix_ok then {
 		tag_and_reject(12, 2); print "prefix not in client's r_set - REJECTING ", net; accept;


### PR DESCRIPTION
bgp_path.last is consistent with RFC 6907 7.1.9-11 according to BIRD
developers.

I think I misunderstood what `last_nonaggregated` does when I recommended it, what do you think?