### PR TITLE
only build prefixes in as_set if the option is enabled

### DIFF
--- a/pierky/arouteserver/builder.py
+++ b/pierky/arouteserver/builder.py
@@ -521,9 +521,13 @@ class ConfigBuilder(object):
         if irrdb_cfg["peering_db"]:
             used_enricher_classes += [PeeringDBConfigEnricher_ASSet]
 
-        used_enricher_classes += [IRRDBConfigEnricher_ASNs,
-                                  IRRDBConfigEnricher_Prefixes,
-                                  PeeringDBConfigEnricher_MaxPrefix]
+        if filtering["irrdb"]["enforce_origin_in_as_set"]:
+            used_enricher_classes.append(IRRDBConfigEnricher_ASNs)
+
+        if filtering["irrdb"]["enforce_prefix_in_as_set"]:
+            used_enricher_classes.append(IRRDBConfigEnricher_Prefixes)
+
+        used_enricher_classes.append(PeeringDBConfigEnricher_MaxPrefix)
 
         if self.cfg_general.rtt_based_functions_are_used:
             used_enricher_classes.append(RTTGetterConfigEnricher)


### PR DESCRIPTION
Only run IRRDBConfigEnricher_ASNs & IRRDBConfigEnricher_Prefixes if the options are enabled.

When 'enforce_prefix_in_as_set' is set to False, we are still generating prefix lists with bqpq3/4 and putting them into the resulting configuration.

This stops them being generated, and stops them being put into the configuration files. Reducing the number of lines, the size, and the time to build each file.

