### PR TITLE
Added NIXI in the list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,7 @@ Mentions / endorsements:
 
 Who is using ARouteServer?
 --------------------------
+- `NIXI Mumbai (GPX) <https://nixi.in/>`__, BIRD.
 
 - `BharatIX <https://www.bharatix.net/>`__, BIRD.
 


### PR DESCRIPTION
NIXI Mumbai is using arouteserver with BIRD in their newer PoP at Mumbai GPX.