### PR TITLE
Add step to run arouteserver html

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -70,6 +70,23 @@ docker run \
     ... # other options
 ```
 
+### Textual representation
+
+A [textual representation](https://arouteserver.readthedocs.io/en/latest/USAGE.html#textual-representation) of the route server's options and policies will be generated automatically before the route server configuration is generated if the directory `/root/arouteserver_html` exists.
+
+Mount a writable directory to `/root/arouteserver_html` to enable generating textual representation.
+
+```bash
+# This is the local directory where HTML files will be stored:
+mkdir ~/arouteserver_html
+
+docker run \
+    -it \
+    --rm \
+    -v ~/arouteserver_html:/root/arouteserver_html \
+    ... # other options
+```
+
 ### Interactive execution
 
 To experiment with the tool, the Docker image can be executed interactively:

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -28,6 +28,7 @@ IP_VER="${IP_VER}"
 
 CLIENTS_FILE_PATH="/root/clients.txt"
 OUTPUT_DIR="/root/arouteserver_configs"
+OUTPUT_DIR_HTML="/root/arouteserver_html"
 
 if [[ ! -e "${OUTPUT_DIR}" && ! -d "${OUTPUT_DIR}" ]]; then
     error "The output directory ${OUTPUT_DIR} can't be found.
@@ -95,6 +96,26 @@ if [[ ! -e /etc/arouteserver/general.yml ]]; then
 else
     echo ""
     bold "The user-provided configuration from general.yml will be used."
+    echo ""
+fi
+
+if [[ -e "${OUTPUT_DIR_HTML}" && -d "${OUTPUT_DIR_HTML}" ]]; then
+    OUTPUT_FILE_HTML="${DAEMON}.html"
+
+    echo ""
+    echo "Generating HTML textual representation of route server's options and policies"
+    echo ""
+
+    OUTPUT_PATH_HTML="${OUTPUT_DIR_HTML}/${OUTPUT_FILE_HTML}"
+
+    arouteserver \
+        html \
+        --clients "${CLIENTS_FILE_PATH}" \
+        -o "${OUTPUT_PATH_HTML}"
+
+    echo ""
+    bold "Textual representation of route server policy for ${DAEMON} saved to ${OUTPUT_PATH_HTML} (path on the container)."
+    echo "You will find the textual representation file in your host system, inside the directory that you mounted at run-time."
     echo ""
 fi
 


### PR DESCRIPTION
This is a proposal first draft (untested) for running `arouteserver html` as a step before config file generation if the `$OUTPUT_DIR_HTML` `/root/arouteserver_html` exists (option `-v /root/arouteserver_html:/root/arouteserver_html` passed to `docker run`).

I am sure this can be polished further if there is interest to implement such a feature. I can volunteer for that if necessary.

For #69.