### PR TITLE
Proposed referring to default logging configuration

### DIFF
--- a/docs/CONFIG.rst
+++ b/docs/CONFIG.rst
@@ -431,6 +431,12 @@ These files must be present on the host running the route server.
 
 The ``logging`` label has a special meaning: when it's used in the ``--local-files-dir`` option, the default logging settings of the BGP speaker are omitted, and they are replaced by the *include* statement.
 
+To determine the default logging configuration, please refer to the template files:
+
+- `BIRD <https://github.com/pierky/arouteserver/tree/master/templates/bird>`__: see  `header.j2 <https://github.com/pierky/arouteserver/blob/master/templates/bird/header.j2>`__ 
+
+- `OpenBGPD <https://github.com/pierky/arouteserver/tree/master/templates/openbgpd>`__: see `header.j2 <https://github.com/pierky/arouteserver/blob/master/templates/openbgpd/header.j2>`__
+
 - Example, BIRD, ``logging`` being used:
 
   .. code::


### PR DESCRIPTION
I think it would be good to refer the reader to the default logging configuration.

However this is repeating the links above, where the links are listed with text about "determining location of the includes". So I am not 100% sure this is a good idea.