### PR TITLE
fix 4bASN bug ;add interface and enh support for bird

### DIFF
--- a/pierky/arouteserver/config/clients.py
+++ b/pierky/arouteserver/config/clients.py
@@ -52,10 +52,10 @@ class ConfigParserClients(ConfigParserBase):
         schema = {
             "asn": ValidatorASN(),
             "ip": ValidatorIPAddr(),
-            "interface": ValidatorInterface(mandatory=False),
             "description": ValidatorText(mandatory=False),
             "password": ValidatorText(mandatory=False),
             "cfg": {
+                "interface": ValidatorInterface(mandatory=False),
                 "extended_next_hop": ValidatorBool(mandatory=False),
                 "prepend_rs_as": ValidatorBool(mandatory=False),
                 "passive": ValidatorBool(mandatory=False),

--- a/pierky/arouteserver/config/clients.py
+++ b/pierky/arouteserver/config/clients.py
@@ -52,9 +52,11 @@ class ConfigParserClients(ConfigParserBase):
         schema = {
             "asn": ValidatorASN(),
             "ip": ValidatorIPAddr(),
+            "interface": ValidatorInterface(mandatory=False),
             "description": ValidatorText(mandatory=False),
             "password": ValidatorText(mandatory=False),
             "cfg": {
+                "extended_next_hop": ValidatorBool(mandatory=False),
                 "prepend_rs_as": ValidatorBool(mandatory=False),
                 "passive": ValidatorBool(mandatory=False),
                 "gtsm": ValidatorBool(mandatory=False),

--- a/pierky/arouteserver/config/general.py
+++ b/pierky/arouteserver/config/general.py
@@ -111,6 +111,8 @@ class ConfigParserGeneral(ConfigParserBase):
         c["path_hiding"] = ValidatorBool(default=True)
         c["passive"] = ValidatorBool(default=True)
         c["multihop"] = ValidatorUInt(mandatory=False)
+        c["interface"] = ValidatorInterface(mandatory=False)
+        c["extended_next_hop"] = ValidatorUInt(default=False)
         c["gtsm"] = ValidatorBool(default=False)
         c["add_path"] = ValidatorBool(default=False)
 

--- a/pierky/arouteserver/config/general.py
+++ b/pierky/arouteserver/config/general.py
@@ -125,6 +125,9 @@ class ConfigParserGeneral(ConfigParserBase):
             ("strict", "same-as", "authorized_addresses"),
             default="strict"
         )
+        f["next_hop"]["authorized_addresses_list"] = ValidatorListOf(
+            ValidatorIPAddr, mandatory=False
+        )
         f["ipv4_pref_len"] = ValidatorIPMinMaxLen(
             4, default={"min": 8, "max": 24}
         )

--- a/pierky/arouteserver/config/validators.py
+++ b/pierky/arouteserver/config/validators.py
@@ -76,9 +76,11 @@ class ValidatorInterface(ConfigParserValidator):
 
     def _validate(self, v):
         IFNAMSIZ = 16
-        IlligalCharacters = set(" \\")
+        IlligalCharacters = set(" /")
         if v is not None:
             ifname = str(v)
+            if ifname == "/":
+                return ifname
             if len(ifname) >= IFNAMSIZ:
                 raise ConfigError("Interface name can't exceed 16(IFNAMSIZ)")
             if len(set(ifname) & IlligalCharacters) > 0:

--- a/pierky/arouteserver/config/validators.py
+++ b/pierky/arouteserver/config/validators.py
@@ -72,6 +72,20 @@ class ValidatorUInt(ConfigParserValidator):
                 raise ConfigError()
         raise ConfigError()
 
+class ValidatorInterface(ConfigParserValidator):
+
+    def _validate(self, v):
+        IFNAMSIZ = 16
+        IlligalCharacters = set(" \\")
+        if v is not None:
+            ifname = str(v)
+            if len(ifname) >= IFNAMSIZ:
+                raise ConfigError("Interface name can't exceed 16(IFNAMSIZ)")
+            if len(set(ifname) & IlligalCharacters) > 0:
+                raise ConfigError("Interface name can't contain '/' or any whitespace characters")
+            return ifname
+        return None
+
 class ValidatorText(ConfigParserValidator):
 
     def _validate(self, v):

--- a/templates/bird/clients.j2
+++ b/templates/bird/clients.j2
@@ -400,8 +400,8 @@ protocol bgp {{ client.id }} {
 	neighbor {{ client.ip }} as {{ client.asn }};
 	rs client;
 
-	{% if client.interface %}
-	interface "{{ client.interface }}";
+	{% if client.cfg.interface and client.cfg.interface != '/' %}
+	interface "{{ client.cfg.interface }}";
 	{% endif -%}
 
 	{% if client.password %}

--- a/templates/bird/clients.j2
+++ b/templates/bird/clients.j2
@@ -400,6 +400,10 @@ protocol bgp {{ client.id }} {
 	neighbor {{ client.ip }} as {{ client.asn }};
 	rs client;
 
+	{% if client.interface %}
+	interface "{{ client.interface }}";
+	{% endif -%}
+
 	{% if client.password %}
 	password "{{ client.password }}";
 	{% endif -%}
@@ -457,6 +461,10 @@ protocol bgp {{ client.id }} {
 	{% 	endif %}
 	{% endif %}
 
+	{% if "2.0.8"|target_version_ge and client.ip|ipaddr_ver == 6 and client.cfg.extended_next_hop %}
+	extended next hop on;
+	{% endif %}
+
 	{% if "2.0.0"|target_version_ge %}
 	import table on;
 	{% endif %}
@@ -477,6 +485,7 @@ protocol bgp {{ client.id }} {
 	{% else %}
 	{{ "client6"|include_local_file -}}
 	{% endif %}
+
 }
 
 {% endfor -%}

--- a/templates/bird/macros.j2
+++ b/templates/bird/macros.j2
@@ -71,7 +71,9 @@
 {%	if comm.ext %}
 {%		if replace_peer_as %}
 {{ indent }}bgp_ext_community.delete([{{ write_community(comm.ext, "1..64511") }}]);
+{%			if comm.ext.split(":")[1]|int < 65536 and comm.ext.split(":")[2]|int < 65536 %}
 {{ indent }}bgp_ext_community.delete([{{ write_community(comm.ext, "131072..4199999999") }}]);
+{%			endif %}
 {%		elif replace_dyn_val %}
 {{ indent }}bgp_ext_community.delete([{{ write_community(comm.ext, replace_dyn_val=replace_dyn_val) }}]);
 {%		else %}


### PR DESCRIPTION
## 1. Do not generate (comm.ext, "131072..4199999999") if router_asn is 4 byte
When I use 4bytes router AS(114514) with this client.yml
![image](https://user-images.githubusercontent.com/73118488/160687995-5db41851-7eea-4296-9c2e-1e1f150c1073.png)

It will geneeate this bird configs:
![image](https://user-images.githubusercontent.com/73118488/160688160-90c4e919-a865-4010-ab8d-8359b46b5be9.png)

Which cause this error:
![image](https://user-images.githubusercontent.com/73118488/160688393-b7aecbe3-08e7-43f2-902a-2ea00ea31355.png)

Because we can't put two 4byte value into the extended community
![image](https://user-images.githubusercontent.com/73118488/160689381-33e70f8a-81ff-4329-9484-132d607086ec.png)

So I add a check at templates/bird/macros.j2 line L74, if there are any 4 byte value in the comm.ext, it will skip the line.

Router AS1145:
![image](https://user-images.githubusercontent.com/73118488/160689961-4521b915-d091-4c62-8af3-72f29a128481.png)
Router AS114514:
![image](https://user-images.githubusercontent.com/73118488/160689884-526be391-bdf7-4c1c-bef4-5ba0865b6e5a.png)

## 2. Add `interface` and `extended next hop` section support for bird
client.yml
![image](https://user-images.githubusercontent.com/73118488/160970200-dc15773d-c24d-4453-8887-1b4487c6c073.png)

Result:
![image](https://user-images.githubusercontent.com/73118488/160690450-32f2b6d6-b0b5-4782-8e8e-3e4b300187e8.png)

* Note:  `extended next hop` only works properly at bird >= 2.0.8
