### PR TITLE
Update general.py

### DIFF
--- a/pierky/arouteserver/config/general.py
+++ b/pierky/arouteserver/config/general.py
@@ -107,6 +107,8 @@ class ConfigParserGeneral(ConfigParserBase):
 
         c["rs_as"] = ValidatorASN()
         c["router_id"] = ValidatorIPv4Addr(mandatory=True)
+        c["rs_listen_v4"] = ValidatorIPv4Addr(mandatory=False)
+        c["rs_listen_v6"] = ValidatorIPv6Addr(mandatory=False)
         c["prepend_rs_as"] = ValidatorBool(default=False)
         c["path_hiding"] = ValidatorBool(default=True)
         c["passive"] = ValidatorBool(default=True)


### PR DESCRIPTION
Adding the option of configuring deamon listen IPs via j2 template:

For example:

general.yml
```
cfg:
  rs_as: 6695
  router_id: 1.3.3.7
  rs_listen_v4: 172.31.206.157
  rs_listen_v6: 2001:db8::1a27:5051:ce9d
```
custom_templates/openbgpd/header.j2 
```
AS {{ cfg.rs_as }}
router-id {{ cfg.router_id }}

## custom_templates/openbgpd/header.j2
listen on {% if cfg.rs_listen_v4 is current_ipver %} {{ cfg.rs_listen_v4 }} {% else %} {{ cfg.rs_listen_v6 }} {% endif +%}
socket "/run/bgpd-rs-ipv{{ ip_ver }}-sock.0"
```