### PR TITLE
registrobr: fix exception in https source handling

### DIFF
--- a/pierky/arouteserver/registro_br_db_dump.py
+++ b/pierky/arouteserver/registro_br_db_dump.py
@@ -106,7 +106,7 @@ class RegistroBRWhoisDBDump(CachedObject):
             url = self.source
             try:
                 response = requests.get(url)
-                raw_data = response.text
+                raw_data = response.raw.read()
             except Exception as e:
                 raise RegistroBRWhoisDBDumpError(
                     "Error while retrieving Registro.br Whois DB dump "


### PR DESCRIPTION
We want to avoid to use ftp to download the registro.br db dump and prefer to use https instead. Switching the protocol in the configuration throws an exception in [`RegistroBRWhoisDBDump`](https://github.com/dd-ix/arouteserver/blob/643f528e8c0e1b7327dcfd2c26864daa34c48c9e/pierky/arouteserver/registro_br_db_dump.py#L153):

  *ERROR Can't decode [Registro.br](http://registro.br/) Whois DB raw file: 'str' object has no attribute 'decode' - The error occurred while loading the IRR data from https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt. If the data was moved to a different location, it is possible to adjust the configuration by changing the value of 'filtering.irrdb.use_registrobr_bulk_whois_data.source' inside the general.yml file.*

This patch fixes the handling of the `requests.get()` response.


Cheers from @dd-ix
