### PR TITLE
Add support for RFC8950 peers

### DIFF
--- a/config.d/clients.yml
+++ b/config.d/clients.yml
@@ -109,6 +109,8 @@ clients:
 
       #add_path: False
 
+      #rfc8950: False
+
       filtering:
 
         next_hop:

--- a/config.d/general.yml
+++ b/config.d/general.yml
@@ -94,6 +94,19 @@ cfg:
   # Default: False
   add_path: False
 
+  # Support IPv6 next-hop for IPv4 NLRI (RFC8950)
+  # Will only be enabled for IPv6 BGP sessions.
+  # https://tools.ietf.org/html/rfc8950
+  #
+  # BIRD: enables extended next-hop (available since 2.0)
+  #
+  # OpenBGPD: not yet supported
+  #
+  # Can be overwritten on a client-by-client basis.
+  #
+  # Default: False
+  rfc8950: False
+
   filtering:
     # NEXT_HOP checks
     #

--- a/pierky/arouteserver/builder.py
+++ b/pierky/arouteserver/builder.py
@@ -1065,6 +1065,7 @@ class OpenBGPDConfigBuilder(ConfigBuilder):
                         ["transit_free_action",
                         "add_path", "max_prefix_action",
                         "max_prefix_count_rejected_routes",
+                        "rfc8950",
                         "extended_communities",
                         "internal_communities",
                         "roles_discouraged"]
@@ -1100,6 +1101,7 @@ class OpenBGPDConfigBuilder(ConfigBuilder):
         add_path_clients = []
         max_prefix_action_clients = []
         max_prefix_count_rejected_routes_clients = []
+        rfc8950_clients = []
         for client in self.cfg_clients.cfg["clients"]:
             if client["cfg"]["add_path"]:
                 add_path_clients.append(client["ip"])
@@ -1112,6 +1114,9 @@ class OpenBGPDConfigBuilder(ConfigBuilder):
             max_prefix_count_rejected_routes = client["cfg"]["filtering"]["max_prefix"]["count_rejected_routes"]
             if not max_prefix_count_rejected_routes:
                 max_prefix_count_rejected_routes_clients.append(client["ip"])
+
+            if client["cfg"]["rfc8950"]:
+                rfc8950_clients.append(client["ip"])
 
         if add_path_clients and \
             version.parse(self.target_version) < version.parse("7.5"):
@@ -1151,6 +1156,19 @@ class OpenBGPDConfigBuilder(ConfigBuilder):
                 "the following clients: {}{}; in OpenBGPD, the "
                 "only available behaviour is to have the "
                 "rejected routes counted towards the limit.".format(
+                    ", ".join(clients[:3]),
+                    "" if cnt <= 3 else " and {} more".format(cnt - 3)
+                )
+            ):
+                res = False
+
+        if rfc8950_clients:
+            clients = rfc8950_clients
+            cnt = len(clients)
+            if not self.process_compatibility_issue(
+                "rfc8950",
+                "RFC8950 not supported by OpenBGPD but "
+                "enabled for the following clients: {}{}.".format(
                     ", ".join(clients[:3]),
                     "" if cnt <= 3 else " and {} more".format(cnt - 3)
                 )

--- a/pierky/arouteserver/config/clients.py
+++ b/pierky/arouteserver/config/clients.py
@@ -64,6 +64,7 @@ class ConfigParserClients(ConfigParserBase):
                 "gtsm": ValidatorBool(mandatory=False),
                 "multihop": ValidatorUInt(mandatory=False),
                 "add_path": ValidatorBool(mandatory=False),
+                "rfc8950": ValidatorBool(mandatory=False),
                 "filtering": {
                     "next_hop": {
                         "policy": ValidatorOption("policy",

--- a/pierky/arouteserver/config/general.py
+++ b/pierky/arouteserver/config/general.py
@@ -115,6 +115,7 @@ class ConfigParserGeneral(ConfigParserBase):
         c["multihop"] = ValidatorUInt(mandatory=False)
         c["gtsm"] = ValidatorBool(default=False)
         c["add_path"] = ValidatorBool(default=False)
+        c["rfc8950"] = ValidatorBool(default=False)
 
         c["filtering"] = OrderedDict()
         f = c["filtering"]

--- a/templates/bird/clients.j2
+++ b/templates/bird/clients.j2
@@ -198,8 +198,8 @@ bool validated;
 	# Client's white list
 {%          if "2.0"|target_version_ge and client.cfg.rfc8950 %}
 {%              set routes = client.cfg.filtering.irrdb.white_list_route|sort(attribute="prefix") %}
-{%          else
-{%              set routes = client.cfg.filtering.irrdb.white_list_route|selectattr("prefix", "is_ipver", client.ip|ipaddr_ver)|sort(attribute="prefix") if route.prefix|ipaddr_ver == client.ip|ipaddr_ver %}
+{%          else %}
+{%              set routes = client.cfg.filtering.irrdb.white_list_route|selectattr("prefix", "is_ipver", client.ip|ipaddr_ver)|sort(attribute="prefix") %}
 {%          endif %}
 {%		for route in routes %}
 	if !validated && net ~ [ {{ write_prefix_list_entry(route) }} ] then {
@@ -476,13 +476,13 @@ protocol bgp {{ client.id }} {
 	interpret communities off;
 	{% endif %}
 
-	{% if "2.0.0"|target_version_ge %}
-	{% if client.cfg.rfc8950 and client.ip|ipaddr_ver == 6 %}
+	{% if "2.0.0"|target_version_ge and client.cfg.rfc8950 and client.ip|ipaddr_ver == 6 %}
 	{%     set afis = [4, 6] %}
 	{% else %}
 	{%     set afis = [ client.ip|ipaddr_ver ] %}
 	{% endif %}
 	{% for current_afi in afis %}
+	{% if "2.0.0"|target_version_ge %}
 	# ---------------------------------------
 	ipv{{ current_afi }} {
 	table master{{ current_afi }};
@@ -530,8 +530,8 @@ protocol bgp {{ client.id }} {
 	{{- write_custom_config_lines(client, "any", "channel")|indent("	") }}
 	# ---------------------------------------
 	};
-	{% endfor %}
 	{% endif %}
+	{% endfor %}
 
 	{{- write_custom_config_lines(client, "ipv" ~ client.ip, "protocol")|indent("	") }}
 	{{- write_custom_config_lines(client, "any", "protocol")|indent("	") }}

--- a/templates/bird/clients.j2
+++ b/templates/bird/clients.j2
@@ -57,22 +57,28 @@ function origin_as_is_in_{{ client.id }}_as_set(){{ bird_fnc_type("bool") }} {
 # R-SET for {{ client.id }}
 function prefix_is_in_{{ client.id }}_as_set(){{ bird_fnc_type("bool") }} {
 {% if client.cfg.filtering.irrdb.as_set_bundle_ids %}
-{%	for as_set_bundle_id in client.cfg.filtering.irrdb.as_set_bundle_ids|sort %}
-{%    set this_ip_ver = client.ip|ipaddr_ver %}
-{%    set prefixes = irrdb_info[as_set_bundle_id].prefixes|selectattr("prefix", "is_ipver", this_ip_ver)|list %}
-{%    if prefixes %}
-{%      if "2.0"|target_version_ge %}
+{%     for as_set_bundle_id in client.cfg.filtering.irrdb.as_set_bundle_ids|sort %}
+{%         if "2.0"|target_version_ge and client.cfg.rfc8950 %}
+{%             set afis = [4, 6] %}
+{%         else %}
+{%             set afis = [ client.ip|ipaddr_ver ] %}
+{%         endif %}
+{%         for this_ip_ver in afis %}
+{%             set prefixes = irrdb_info[as_set_bundle_id].prefixes|selectattr("prefix", "is_ipver", this_ip_ver)|list %}
+{%             if prefixes %}
+{%                 if "2.0"|target_version_ge %}
     if net.type = NET_IP{{ this_ip_ver }} then
         if net ~ AS_SET_{{ irrdb_info[as_set_bundle_id].name }}_prefixes_{{ this_ip_ver }} then
             return true;
-{%      else %}
+{%                 else %}
     if net ~ AS_SET_{{ irrdb_info[as_set_bundle_id].name }}_prefixes_{{ this_ip_ver }} then
         return true;
-{%      endif %}
-{%    else %}
+{%                 endif %}
+{%             else %}
 	# AS-SET {{ irrdb_info[as_set_bundle_id].name }} referenced but empty.
-{%    endif %}
-{%	endfor %}
+{%             endif %}
+{%	   endfor %}
+{%     endfor %}
 {% endif %}
     return false;
 }
@@ -107,7 +113,11 @@ function prefix_is_in_{{ client.id }}_blacklist(){{ bird_fnc_type("bool") }}
 prefix set {{ client.id }}_blacklist;
 {
 	{{ client.id }}_blacklist = [
+{%     if "2.0"|target_version_ge and client.cfg.rfc8950 %}
+{{ write_prefix_list(client.cfg.filtering.black_list_pref) }}
+{%     else %}
 {{ write_prefix_list(client.cfg.filtering.black_list_pref|selectattr("prefix", "is_ipver", client.ip|ipaddr_ver)) }}
+{%     endif %}
 	];
 	return net ~ {{ client.id }}_blacklist;
 }
@@ -186,7 +196,12 @@ bool validated;
 
 {%	if client.cfg.filtering.irrdb.white_list_route %}
 	# Client's white list
-{%		for route in client.cfg.filtering.irrdb.white_list_route|selectattr("prefix", "is_ipver", client.ip|ipaddr_ver)|sort(attribute="prefix") if route.prefix|ipaddr_ver == client.ip|ipaddr_ver %}
+{%          if "2.0"|target_version_ge and client.cfg.rfc8950 %}
+{%              set routes = client.cfg.filtering.irrdb.white_list_route|sort(attribute="prefix") %}
+{%          else
+{%              set routes = client.cfg.filtering.irrdb.white_list_route|selectattr("prefix", "is_ipver", client.ip|ipaddr_ver)|sort(attribute="prefix") if route.prefix|ipaddr_ver == client.ip|ipaddr_ver %}
+{%          endif %}
+{%		for route in routes %}
 	if !validated && net ~ [ {{ write_prefix_list_entry(route) }} ] then {
 {%			if route.asn %}
 		if bgp_path.last = {{ route.asn }} then {
@@ -223,7 +238,11 @@ filter receive_from_{{ client.id }} {
 		{{ reject(client, 65535, '"source != RTS_BGP - REJECTING ", net') }}
 
 	{% if "2.0"|target_version_ge %}
+	{%     if client.cfg.rfc8950 and client.ip|ipaddr_ver == 6%}
+	if !(net.type = NET_IP6 || net.type = NET_IP4) then
+	{%     else %}
 	if !(net.type = NET_IP{{ client.ip|ipaddr_ver }}) then
+	{%     endif %}
 		{{ reject(client, 65535, '"AFI not enabled for this peer - REJECTING ", net') }}
 	{% endif %}
 
@@ -279,7 +298,7 @@ filter receive_from_{{ client.id }} {
 
 	{% if client.ip|ipaddr_ver == 6 %}
 	# Prefix: only IPv6 Global Unicast space allowed
-	if !(net ~ [2000::/3+]) then
+	if net.type = NET_IP6 && !(net ~ [2000::/3+]) then
 		{{ reject(client, 10, '"prefix is not in IPv6 Global Unicast space - REJECTING ", net') }}
 	{% endif %}
 
@@ -458,23 +477,32 @@ protocol bgp {{ client.id }} {
 	{% endif %}
 
 	{% if "2.0.0"|target_version_ge %}
+	{% if client.cfg.rfc8950 and client.ip|ipaddr_ver == 6 %}
+	{%     set afis = [4, 6] %}
+	{% else %}
+	{%     set afis = [ client.ip|ipaddr_ver ] %}
+	{% endif %}
+	{% for current_afi in afis %}
 	# ---------------------------------------
-	ipv{{ client.ip|ipaddr_ver }} {
-	table master{{ client.ip|ipaddr_ver }};
+	ipv{{ current_afi }} {
+	table master{{ current_afi }};
 	{% endif %}
 
 	{% if client.cfg.add_path %}
 	add paths tx;
 	{% endif %}
 
+	{% if client.cfg.rfc8950 and client.ip|ipaddr_ver == 6 and current_afi == 4 %}
+	extended next hop on;
+	{% endif %}
 	{% if cfg.path_hiding %}
 	secondary;
 	{% endif %}
 
 	{% if client.cfg.filtering.max_prefix.action %}
-	{%	if client.ip|ipaddr_ver == 4 and client.cfg.filtering.max_prefix.limit_ipv4 %}
+	{%	if current_afi == 4 and client.cfg.filtering.max_prefix.limit_ipv4 %}
 	{%		set max_pref_limit = client.cfg.filtering.max_prefix.limit_ipv4 %}
-	{% 	elif client.ip|ipaddr_ver == 6 and client.cfg.filtering.max_prefix.limit_ipv6 %}
+	{% 	elif current_afi == 6 and client.cfg.filtering.max_prefix.limit_ipv6 %}
 	{%      	set max_pref_limit = client.cfg.filtering.max_prefix.limit_ipv6 %}
 	{% 	else %}
 	{%		set max_pref_limit = 0 %}
@@ -498,10 +526,11 @@ protocol bgp {{ client.id }} {
 	export filter announce_to_{{ client.id }};
 
 	{%- if "2.0.0"|target_version_ge %}
-	{{- write_custom_config_lines(client, "ipv" ~ client.ip|ipaddr_ver, "channel")|indent("	") }}
+	{{- write_custom_config_lines(client, "ipv" ~ current_afi, "channel")|indent("	") }}
 	{{- write_custom_config_lines(client, "any", "channel")|indent("	") }}
 	# ---------------------------------------
 	};
+	{% endfor %}
 	{% endif %}
 
 	{{- write_custom_config_lines(client, "ipv" ~ client.ip, "protocol")|indent("	") }}

--- a/templates/bird/clients.j2
+++ b/templates/bird/clients.j2
@@ -58,7 +58,7 @@ function origin_as_is_in_{{ client.id }}_as_set(){{ bird_fnc_type("bool") }} {
 function prefix_is_in_{{ client.id }}_as_set(){{ bird_fnc_type("bool") }} {
 {% if client.cfg.filtering.irrdb.as_set_bundle_ids %}
 {%     for as_set_bundle_id in client.cfg.filtering.irrdb.as_set_bundle_ids|sort %}
-{%         if "2.0"|target_version_ge and client.cfg.rfc8950 %}
+{%         if "2.0"|target_version_ge and client.cfg.rfc8950 and client.ip|ipaddr_ver == 6 %}
 {%             set afis = [4, 6] %}
 {%         else %}
 {%             set afis = [ client.ip|ipaddr_ver ] %}
@@ -196,7 +196,7 @@ bool validated;
 
 {%	if client.cfg.filtering.irrdb.white_list_route %}
 	# Client's white list
-{%          if "2.0"|target_version_ge and client.cfg.rfc8950 %}
+{%          if "2.0"|target_version_ge and client.cfg.rfc8950 and client.ip|ipaddr_ver == 6 %}
 {%              set routes = client.cfg.filtering.irrdb.white_list_route|sort(attribute="prefix") %}
 {%          else %}
 {%              set routes = client.cfg.filtering.irrdb.white_list_route|selectattr("prefix", "is_ipver", client.ip|ipaddr_ver)|sort(attribute="prefix") %}


### PR DESCRIPTION
RFC8950 (Advertising IPv4 NLRI with an IPv6 Next Hop) will eventually allow IXP peering LANs to be IPv6 only.

IXP route servers will need to accept and forward IPv4 NLRI in IPv6 peering sessions with an IPv6 next hop.

RFC8950 support may be enabled globally or per client. Default: disabled

OpenBGPD support for RFC8950 is still on the RSSF roadmap.
BIRD support introduced in 2.0.0.