### PR TITLE
Fix prefix length verification for rfc8950 peers

### DIFF
--- a/templates/bird/clients.j2
+++ b/templates/bird/clients.j2
@@ -375,8 +375,17 @@ filter receive_from_{{ client.id }} {
 		{% set min_pref_len = client.cfg.filtering.ipv6_pref_len.min %}
 		{% set max_pref_len = client.cfg.filtering.ipv6_pref_len.max %}
 		{% endif %}
+		{% if "2.0.0"|target_version_ge and client.cfg.rfc8950 and client.ip|ipaddr_ver == 6 %}
+		if net.type = NET_IP6 then {
+		{% endif %}
 		if !prefix_len_is_valid({{ min_pref_len }}, {{ max_pref_len }}) then
 			{{ reject(client, 13, '"prefix len [", net.len, "] not in ' ~ min_pref_len ~ '-' ~ max_pref_len ~ ' - REJECTING ", net') }}
+		{% if "2.0.0"|target_version_ge and client.cfg.rfc8950 and client.ip|ipaddr_ver == 6 %}
+		} else {
+		if !prefix_len_is_valid({{ client.cfg.filtering.ipv4_pref_len.min }}, {{ client.cfg.filtering.ipv4_pref_len.max }}) then
+			{{ reject(client, 13, '"prefix len [", net.len, "] not in ' ~ client.cfg.filtering.ipv4_pref_len.min ~ '-' ~ client.cfg.filtering.ipv4_pref_len.max ~ ' - REJECTING ", net') }}
+		}
+		{% endif %}
 
 		{% if cfg.graceful_shutdown.enabled %}
 		{%	if client.cfg.graceful_shutdown.enabled %}


### PR DESCRIPTION
Potential fix for issue #130 

I tried to keep the differences for non-rfc8950 peers minimal. This causes a bit of code duplication.