### PR TITLE
registro.br: parse gracefully, logging but skipping errors

### DIFF
--- a/pierky/arouteserver/registro_br_db_dump.py
+++ b/pierky/arouteserver/registro_br_db_dump.py
@@ -47,13 +47,15 @@ class RegistroBRWhoisDBDump(CachedObject):
             for row in raw.splitlines():
                 if not row.strip():
                     continue
-                if "|" not in row:
-                    raise ValueError(
-                        "unknown record format, missing field separator ('|')"
-                    )
                 try:
+                    if "|" not in row:
+                        raise ValueError(
+                            "unknown record format, missing field separator ('|')"
+                        )
                     fields = row.split("|")
                     if len(fields) < 3:
+                        if fields[1] == "--whois err--":
+                            continue
                         raise ValueError(
                             "unknown record format, less than 3 fields found"
                         )
@@ -77,11 +79,12 @@ class RegistroBRWhoisDBDump(CachedObject):
                             "prefix": prefix
                         })
                 except ValueError as e:
-                    raise ValueError(
+                    logging.warning(
                         "invalid record '{}': {}".format(
                             str(raw), str(e)
                         )
                     )
+                    continue
         except ValueError as e:
             msg = (
                 "An error occurred while processing the Registro.br Whois "


### PR DESCRIPTION
I'm getting some errors in using the registro.br WHOIS DB dumps when they have WHOIS errors.

Sometimes in the ftp://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt file, there will be some lines like:

```
23106|--whois err--
23202|--whois err--
26622|--whois err--
27652|--whois err--
27656|--whois err--
27715|--whois err--
28125|--whois err--
28127|--whois err--
28132|--whois err--
```

This breaks arouteserver when [parsing this dump and asserts that there are always at least three fields](https://github.com/pierky/arouteserver/blob/cb706370e47fba47c3b714027cd56e194eed1c54/pierky/arouteserver/registro_br_db_dump.py#L55-L59) per row.

It would be ideal if arouteserver would gather whatever prefix/origin mappings it can from a source, even if there are errors in parsing some records. Some up-to-date information is better than no updated information.
Instead of failing the entire source for one error, this change just skips over those error-generating lines and doesn't add origination info for them from the dump.