### PR TITLE
add DD-IX to user list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,6 +176,8 @@ Who is using ARouteServer?
 
 - `CNX <http://cnx.net.kh/>`__, BIRD v2.
 
+- `DD-IX <https://dd-ix.net/>`__, BIRD v2.
+
 - `DO-IX <https://www.do-ix.net/>`__, BIRD.
 
 - `EVIX <https://evix.org/>`__, BIRD.


### PR DESCRIPTION
We use ARouteServer at DD-IX right from the beginning.

Thanks! :pray: 