### PR TITLE
Limit to one prefixe and asn per line

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -31,6 +31,7 @@ LOCAL_FILES_DIR="${LOCAL_FILES_DIR}"
 TEMPLATES_DIR="${TEMPLATES_DIR}"
 EURO_IX_URL="${EURO_IX_URL}"
 EURO_IX_IXP_ID="${EURO_IX_IXP_ID}"
+HOOKS="${HOOKS}"
 
 CLIENTS_FILE_PATH="/root/clients.yml"
 OUTPUT_DIR="/root/arouteserver_configs"
@@ -209,6 +210,11 @@ if [[ -n "${LOCAL_FILES}" ]]; then
     fi
 fi
 
+HOOKS_ARG=""
+if [[ -n "${HOOKS}" ]]; then
+     HOOKS_ARG="--use-hooks ${HOOKS}"
+fi
+
 TEMPLATES_DIR_ARG=""
 
 if [[ -n "${TEMPLATES_DIR}" ]]; then
@@ -225,6 +231,7 @@ arouteserver \
     --clients "${CLIENTS_FILE_PATH}" \
     ${LOCAL_FILES_ARG} \
     ${LOCAL_FILES_DIR_ARG} \
+    ${HOOKS_ARG} \
     -o "${OUTPUT_PATH}"
 
 echo ""

--- a/templates/bird/irrdb.j2
+++ b/templates/bird/irrdb.j2
@@ -14,7 +14,7 @@ define AS_SET_{{ as_set_bundle.name }}_asns = [
 {%	for asn in as_set_bundle.asns|sort %}
 {{-		asn -}}
 {%		if not loop.last %}, {% endif %}
-{%		if loop.index % 5 == 0 %}{{ "\n\t" }}{% endif %}
+{%		if loop.index % 1 == 0 %}{{ "\n\t" }}{% endif %}
 {%	endfor %}
 
 ];

--- a/templates/bird/macros.j2
+++ b/templates/bird/macros.j2
@@ -29,7 +29,7 @@
 {{-		write_prefix_list_entry(entry) -}}
 {%		if not loop.last %}
 {%		 	if group %}
-{%				if loop.index % 4 == 0 %}{{ ",\n" -}}{% else %}{{ ", " -}}{% endif %}
+{%				if loop.index % 1 == 0 %}{{ ",\n" -}}{% else %}{{ ", " -}}{% endif %}
 {%		 	else %}
 {{-				",\n" }}
 {%			endif %}


### PR DESCRIPTION
When multiple prefixes or ASNs are defined on a single line in the Bird configuration, it becomes difficult to review diffs between configuration versions—any small change on one line causes the entire block to appear modified.

This update adjusts the Bird templates to use one entry per line, making changes easier to review.

Let me know if you think this behavior should be configurable.

Nitzan